### PR TITLE
Adding raw body to request before it is parsed

### DIFF
--- a/index.js
+++ b/index.js
@@ -170,7 +170,8 @@ function read(req, res, next, parse, options) {
     try {
       str = typeof body !== 'string'
         ? body.toString(encoding)
-        : body
+        : body;
+      req.rawBody = str;
       req.body = parse(str)
     } catch (err){
       err.body = str


### PR DESCRIPTION
I ran into a roadblock when trying to verify an Instant Payment Notification from PayPal on an Express request that was using this module to parse the request body. IPN verification fails when PayPal sends a transaction array in the request.

By storing the raw body contents on the request object before it is parsed by body-parser solves this problem. See https://github.com/andzdroid/paypal-ipn for the IPN verification library I'm using and this outstanding issue describing the erroring scenario: https://github.com/andzdroid/paypal-ipn/issues/6.

It may be possible to somehow use the body-parser options to fix the problem outlined here, but this solution solves the problem without requiring any code changes for people using middleware like: 

``` js
app.use(bodyParser());
```

The code to verify an IPN now looks something like this:

``` js
var qs = require('querystring');
var PayPalIPN = require('paypal-ipn');
var parsedRawBody = qs.parse(req.rawBody);
PayPalIPN.verify(parsedRawBody, function(err, msg){...})
```
