### PR TITLE
Make the raw body string available

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -78,6 +78,9 @@ function read(req, res, next, parse, options) {
       next(err)
       return
     }
+    
+    // make this available outside of this module
+    req.rawBody = body
 
     // verify
     if (verify) {


### PR DESCRIPTION
As far as I can tell, getting the raw body is currently impossible - using the "raw-body" module seems to return false regardless of what I do.

This puts it onto the req object should you want to use it directly instead of after parsing in cases where you need to do so (for example, HMAC checking)
