### PR TITLE
Update json.js

### DIFF
--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -65,7 +65,7 @@ function json(options) {
       }
     }
 
-    return JSON.parse(body, reviver)
+    return JSON.parse(body.trim(), reviver)
   }
 
   return function jsonParser(req, res, next) {


### PR DESCRIPTION
Trim prevents prefix spaces from breaking JSON.parse when JSON starts with a space. Consider this: http://jsfiddle.net/tuoh6qyx/
