### PR TITLE
Pass more options to qs module

### DIFF
--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -99,7 +99,14 @@ function urlencoded(options){
 function extendedparser(options) {
   var parameterLimit = options.parameterLimit !== undefined
     ? options.parameterLimit
+    : 1000,
+  var arrayLimit = options.arrayLimit !== undefined
+    ? options.arrayLimit
+    : 100
+  var depth = options.depth !== undefined
+    ? options.depth
     : 1000
+
   var parse = parser('qs')
 
   if (isNaN(parameterLimit) || parameterLimit < 1) {
@@ -110,9 +117,18 @@ function extendedparser(options) {
     parameterLimit = parameterLimit | 0
   }
 
+  if (isFinite(arrayLimit)) {
+    arrayLimit = arrayLimit | 0
+  }
+
+  if (isFinite(depth)) {
+    depth = depth | 0
+  }
+
   var opts = {
-    arrayLimit: 100,
-    parameterLimit: parameterLimit
+    arrayLimit: arrayLimit,
+    parameterLimit: parameterLimit,
+    depth: depth
   }
 
   return function queryparse(body) {


### PR DESCRIPTION
There was not enough passed options from body-parser to qs module in extended mode.
