### PR TITLE
Make the maximum items in an array configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ The options are:
 - `inflate` - if deflated bodies will be inflated. (default: `true`)
 - `limit` - maximum request body size. (default: `<100kb>`)
 - `parameterLimit` - maximum number of parameters. (default: `1000`)
+  `arrayLimit` - maximum number of array items. (default: `100`)
 - `type` - request content-type to parse (default: `urlencoded`)
 - `verify` - function to verify body content
 

--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -110,8 +110,12 @@ function extendedparser(options) {
     parameterLimit = parameterLimit | 0
   }
 
+  var arrayLimit = options.arrayLimit !== undefined
+    ? options.arrayLimit
+    : 100
+
   var opts = {
-    arrayLimit: 100,
+    arrayLimit: arrayLimit,
     parameterLimit: parameterLimit
   }
 


### PR DESCRIPTION
We're using body-parser to handle a large array however we hit 100 limit and got an unexpected result of the array being converted into an object.

This pull request makes the arrayLimit property configurable for use cases where there is a array larger than 100. Could potentially extend it further to validate and throw an exception if the limit is hit.
