### PR TITLE
Replace JSON.stringify(...) debug logging with %j

### DIFF
--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -96,7 +96,7 @@ function json(options) {
       return debug('skip empty body'), next()
     }
 
-    debug('content-type %s', JSON.stringify(req.headers['content-type']))
+    debug('content-type %j', req.headers['content-type'])
 
     // determine if request should be parsed
     if (!shouldParse(req)) {

--- a/lib/types/raw.js
+++ b/lib/types/raw.js
@@ -62,7 +62,7 @@ function raw(options) {
       return debug('skip empty body'), next()
     }
 
-    debug('content-type %s', JSON.stringify(req.headers['content-type']))
+    debug('content-type %j', req.headers['content-type'])
 
     // determine if request should be parsed
     if (!shouldParse(req)) {

--- a/lib/types/text.js
+++ b/lib/types/text.js
@@ -64,7 +64,7 @@ function text(options) {
       return debug('skip empty body'), next()
     }
 
-    debug('content-type %s', JSON.stringify(req.headers['content-type']))
+    debug('content-type %j', req.headers['content-type'])
 
     // determine if request should be parsed
     if (!shouldParse(req)) {

--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -84,7 +84,7 @@ function urlencoded(options){
       return debug('skip empty body'), next()
     }
 
-    debug('content-type %s', JSON.stringify(req.headers['content-type']))
+    debug('content-type %j', req.headers['content-type'])
 
     // determine if request should be parsed
     if (!shouldParse(req)) {


### PR DESCRIPTION
Replace explicitly calling `JSON.stringify(...)` when debug logging with `%j` so that `JSON.stringify(...)` is only called if logging is actually enabled.

This should save a function call in the normal case where debug logging for body-parser is not enabled.