### PR TITLE
Allow extended options to be passed to qs library

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,14 +211,17 @@ any of the following keys:
 
 The `extended` option allows to choose between parsing the URL-encoded data
 with the `querystring` library (when `false`) or the `qs` library (when
-`true`). The "extended" syntax allows for rich objects and arrays to be
-encoded into the URL-encoded format, allowing for a JSON-like experience
-with URL-encoded. For more information, please
+`true`, or an object). The "extended" syntax allows for rich objects and
+arrays to be encoded into the URL-encoded format, allowing for a JSON-like
+experience with URL-encoded. For more information, please
 [see the qs library](https://www.npmjs.org/package/qs#readme).
 
 Defaults to `true`, but using the default has been deprecated. Please
 research into the difference between `qs` and `querystring` and choose the
 appropriate setting.
+
+You may also set the `extended` option to an object in order to pass
+the `arrayLimit` and `delimiter` options to the underlying `qs` library.
 
 ##### inflate
 

--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -44,7 +44,6 @@ function urlencoded(options){
     deprecate('undefined extended: provide extended option')
   }
 
-  var extended = options.extended !== false
   var inflate = options.inflate !== false
   var limit = typeof options.limit !== 'number'
     ? bytes(options.limit || '100kb')
@@ -57,8 +56,8 @@ function urlencoded(options){
   }
 
   // create the appropriate query parser
-  var queryparse = extended
-    ? extendedparser(options)
+  var queryparse = options.extended !== false
+    ? extendedparser(options, extended)
     : simpleparser(options)
 
   // create the appropriate type checking function
@@ -117,7 +116,7 @@ function urlencoded(options){
  * @param {object} options
  */
 
-function extendedparser(options) {
+function extendedparser(options, extended) {
   var parameterLimit = options.parameterLimit !== undefined
     ? options.parameterLimit
     : 1000
@@ -141,11 +140,14 @@ function extendedparser(options) {
       throw err
     }
 
-    var arrayLimit = Math.max(100, paramCount)
+    var arrayLimit = (extended && extended.arrayLimit) !== undefined
+      ? extended.arrayLimit
+      : Math.max(100, paramCount)
 
     debug('parse extended urlencoding')
     return parse(body, {
       arrayLimit: arrayLimit,
+      delimiter: extended && extended.delimiter,
       depth: Infinity,
       parameterLimit: parameterLimit
     })

--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -57,7 +57,7 @@ function urlencoded(options){
 
   // create the appropriate query parser
   var queryparse = options.extended !== false
-    ? extendedparser(options, extended)
+    ? extendedparser(options, options.extended)
     : simpleparser(options)
 
   // create the appropriate type checking function

--- a/test/urlencoded.js
+++ b/test/urlencoded.js
@@ -189,6 +189,21 @@ describe('bodyParser.urlencoded()', function(){
         .expect(200, done)
       })
     })
+
+    describe('when object', function () {
+      var server;
+      before(function(){
+        server = createServer({ extended: { arrayLimit: 0, delimiter: ';' } })
+      })
+
+      it('should parse array index notation as object', function(done){
+        request(server)
+        .post('/')
+        .set('Content-Type', 'application/x-www-form-urlencoded')
+        .send('foo[0]=bar;foo[1]=baz')
+        .expect(200, '{"foo":{"0":"bar","1":"baz"}}', done)
+      })
+    })
   })
 
   describe('with inflate option', function(){


### PR DESCRIPTION
This allows the options such as `arrayLimit` and `delimiter` to be passed to the `qs` library.

```js
app.use('/path', bodyParser.urlencoded({
  extended: {
    arrayLimit: 0,
    delimiter: ';'
  }
}));
```

The main benefit of this is that setting `arrayLimit` to 0 causes arrays to be represented as objects, allowing "sparse" arrays like the following:

```js
// foo[0]=1&foo[5]=hello
{ foo: { 0: 1, 5: "hello" } }
```