### PR TITLE
deps: bytes@~2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "repository": "expressjs/body-parser",
   "dependencies": {
-    "bytes": "1.0.0",
+    "bytes": "~2.1.0",
     "content-type": "~1.0.1",
     "debug": "~2.2.0",
     "depd": "~1.0.1",


### PR DESCRIPTION
This way body-parser and raw-body are using the same version.
This makes npm dedupe don't print a warning anymore.