### PR TITLE
fix typo for JSON parsing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ All the parsers accept a `type` option which allows you to change the
 
 ```js
 // parse various different custom JSON types as JSON
-app.use(bodyParser.json({ type: 'application/*+json' }))
+app.use(bodyParser.json({ type: 'json' }))
 
 // parse some custom thing into a Buffer
 app.use(bodyParser.raw({ type: 'application/vnd.custom-type' }))


### PR DESCRIPTION
`type` doesn't accept a regex. it uses `type-is` under the hood.