### PR TITLE
Less confusing error message

### DIFF
--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -111,7 +111,7 @@ function json(options) {
     var charset = getCharset(req) || 'utf-8'
     if (charset.substr(0, 4) !== 'utf-') {
       debug('invalid charset')
-      next(createError(415, 'unsupported charset "' + charset.toUpperCase() + '"', {
+      next(createError(415, 'JSON must be a format of UTF-* (RFC 7159)', {
         charset: charset
       }))
       return


### PR DESCRIPTION
Was confused why this wasn't working when npm showed ISO-8859-1 was supported. This error message should prevent future confusion.