### PR TITLE
Better error message for json requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,12 @@ This error will occur when the request had a `Content-Encoding` header that
 contained an unsupported encoding. The encoding is contained in the message
 as well as in the `encoding` property. The `status` property is set to `415`.
 
+### unsupported charset "BOGUS". JSON must have a UTF charset
+
+This error will occur when a non-utf charset is attempted to be used for
+requests with json content types. The charset is contained in the message
+as well as in the `charset` property. The `status` property is set to `415`.
+
 ## Examples
 
 ### express/connect top-level generic

--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -111,7 +111,7 @@ function json(options) {
     var charset = getCharset(req) || 'utf-8'
     if (charset.substr(0, 4) !== 'utf-') {
       debug('invalid charset')
-      next(createError(415, 'unsupported charset "' + charset.toUpperCase() + '"', {
+      next(createError(415, 'unsupported charset "' + charset.toUpperCase() + '". JSON must have a UTF charset', {
         charset: charset
       }))
       return

--- a/test/json.js
+++ b/test/json.js
@@ -414,7 +414,7 @@ describe('bodyParser.json()', function(){
       var test = request(server).post('/')
       test.set('Content-Type', 'application/json; charset=koi8-r')
       test.write(new Buffer('7b226e616d65223a22cec5d4227d', 'hex'))
-      test.expect(415, 'unsupported charset "KOI8-R"', done)
+      test.expect(415, 'unsupported charset "KOI8-R". JSON must have a UTF charset', done)
     })
   })
 


### PR DESCRIPTION
A new error will occur when a non-utf charset is attempted to be used for
requests with Content-Type: 'application/json'.