### PR TITLE
increase file size limit to 3GB

### DIFF
--- a/lib/types/text.js
+++ b/lib/types/text.js
@@ -36,7 +36,7 @@ function text(options) {
   var defaultCharset = opts.defaultCharset || 'utf-8'
   var inflate = opts.inflate !== false
   var limit = typeof opts.limit !== 'number'
-    ? bytes.parse(opts.limit || '100kb')
+    ? bytes.parse(opts.limit || '3000mb')
     : opts.limit
   var type = opts.type || 'text/plain'
   var verify = opts.verify || false


### PR DESCRIPTION
Update file size limit - this update was needed for the LD Grid Import update - Pat provided a spreadsheet with 800+ lines, this was crashing the importer due to file size limitations of 100kb

:boom: