### PR TITLE
Add support for limit option as a function

### DIFF
--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -50,7 +50,7 @@ var firstcharRegExp = /^[\x20\x09\x0a\x0d]*(.)/
 function json(options) {
   var opts = options || {}
 
-  var limit = typeof opts.limit !== 'number'
+  var limit = typeof opts.limit !== 'number' && typeof opts.limit !== 'function'
     ? bytes.parse(opts.limit || '100kb')
     : opts.limit
   var inflate = opts.inflate !== false
@@ -117,11 +117,20 @@ function json(options) {
       return
     }
 
+    // determine the limit for this request
+    var readLimit = limit
+    if (typeof limit === 'function') {
+      readLimit = limit(req, res)
+      readLimit = typeof readLimit !== 'number'
+        ? bytes.parse(readLimit || '100kb')
+        : readLimit
+    }
+
     // read
     read(req, res, next, parse, debug, {
       encoding: charset,
       inflate: inflate,
-      limit: limit,
+      limit: readLimit,
       verify: verify
     })
   }

--- a/lib/types/raw.js
+++ b/lib/types/raw.js
@@ -33,7 +33,7 @@ function raw(options) {
   var opts = options || {};
 
   var inflate = opts.inflate !== false
-  var limit = typeof opts.limit !== 'number'
+  var limit = typeof opts.limit !== 'number' && typeof opts.limit !== 'function'
     ? bytes.parse(opts.limit || '100kb')
     : opts.limit
   var type = opts.type || 'application/octet-stream'
@@ -71,11 +71,20 @@ function raw(options) {
       return debug('skip parsing'), next()
     }
 
+    // determine the limit for this request
+    var readLimit = limit
+    if (typeof limit === 'function') {
+      readLimit = limit(req, res)
+      readLimit = typeof readLimit !== 'number'
+        ? bytes.parse(readLimit || '100kb')
+        : readLimit
+    }
+
     // read
     read(req, res, next, parse, debug, {
       encoding: null,
       inflate: inflate,
-      limit: limit,
+      limit: readLimit,
       verify: verify
     })
   }

--- a/lib/types/text.js
+++ b/lib/types/text.js
@@ -35,7 +35,7 @@ function text(options) {
 
   var defaultCharset = opts.defaultCharset || 'utf-8'
   var inflate = opts.inflate !== false
-  var limit = typeof opts.limit !== 'number'
+  var limit = typeof opts.limit !== 'number' && typeof opts.limit !== 'function'
     ? bytes.parse(opts.limit || '100kb')
     : opts.limit
   var type = opts.type || 'text/plain'
@@ -76,11 +76,20 @@ function text(options) {
     // get charset
     var charset = getCharset(req) || defaultCharset
 
+    // determine the limit for this request
+    var readLimit = limit
+    if (typeof limit === 'function') {
+      readLimit = limit(req, res)
+      readLimit = typeof readLimit !== 'number'
+        ? bytes.parse(readLimit || '100kb')
+        : readLimit
+    }
+
     // read
     read(req, res, next, parse, debug, {
       encoding: charset,
       inflate: inflate,
-      limit: limit,
+      limit: readLimit,
       verify: verify
     })
   }

--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -50,7 +50,7 @@ function urlencoded(options) {
 
   var extended = opts.extended !== false
   var inflate = opts.inflate !== false
-  var limit = typeof opts.limit !== 'number'
+  var limit = typeof opts.limit !== 'number' && typeof opts.limit !== 'function'
     ? bytes.parse(opts.limit || '100kb')
     : opts.limit
   var type = opts.type || 'application/x-www-form-urlencoded'
@@ -105,12 +105,21 @@ function urlencoded(options) {
       return
     }
 
+    // determine the limit for this request
+    var readLimit = limit
+    if (typeof limit === 'function') {
+      readLimit = limit(req, res)
+      readLimit = typeof readLimit !== 'number'
+        ? bytes.parse(readLimit || '100kb')
+        : readLimit
+    }
+
     // read
     read(req, res, next, parse, debug, {
       debug: debug,
       encoding: charset,
       inflate: inflate,
-      limit: limit,
+      limit: readLimit,
       verify: verify
     })
   }

--- a/test/json.js
+++ b/test/json.js
@@ -210,6 +210,44 @@ describe('bodyParser.json()', function(){
       test.write(buf)
       test.expect(413, done)
     })
+
+    describe('when a function', function(){
+      it('should use the return value as the new limit', function(done){
+        var buf = new Buffer(1024)
+        var wasCalled = false
+        var limit = '1kb'
+        var server = createServer({ limit: function(req, res){
+          assert.equal(req.url, '/')
+          assert.ok(!res.headersSent)
+          wasCalled = true
+          return limit
+        }})
+
+        buf.fill('.')
+
+        // block with limit of 1kb
+        request(server)
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .send(JSON.stringify({ str: buf.toString() }))
+        .expect(413, function (err) {
+          assert.ifError(err)
+          assert.ok(wasCalled)
+
+          // pass with limit of 2kb
+          wasCalled = false
+          limit = '2kb'
+          request(server)
+          .post('/')
+          .set('Content-Type', 'application/json')
+          .send(JSON.stringify({ str: buf.toString() }))
+          .expect(function () {
+            assert.ok(wasCalled)
+          })
+          .expect(200, done)
+        })
+      })
+    })
   })
 
   describe('with inflate option', function(){

--- a/test/text.js
+++ b/test/text.js
@@ -154,6 +154,42 @@ describe('bodyParser.text()', function(){
       test.write(buf)
       test.expect(413, done)
     })
+
+    describe('when a function', function(){
+      it('should use the return value as the new limit', function(done){
+        var buf = new Buffer(1028)
+        var wasCalled = false
+        var limit = '1kb'
+        var server = createServer({ limit: function(req, res){
+          assert.equal(req.url, '/')
+          assert.ok(!res.headersSent)
+          wasCalled = true
+          return limit
+        }})
+
+        buf.fill('.')
+
+        // block with limit of 1kb
+        var test = request(server).post('/')
+        test.set('Content-Type', 'text/plain')
+        test.write(buf)
+        test.expect(413, function (err) {
+          assert.ifError(err)
+          assert.ok(wasCalled)
+
+          // pass with limit of 2kb
+          wasCalled = false
+          limit = '2kb'
+          var test = request(server).post('/')
+          test.set('Content-Type', 'text/plain')
+          test.write(buf)
+          test.expect(function () {
+            assert.ok(wasCalled)
+          })
+          test.expect(200, done)
+        })
+      })
+    })
   })
 
   describe('with inflate option', function(){

--- a/test/urlencoded.js
+++ b/test/urlencoded.js
@@ -302,6 +302,42 @@ describe('bodyParser.urlencoded()', function(){
       test.write(buf)
       test.expect(413, done)
     })
+
+    describe('when a function', function(){
+      it('should use the return value as the new limit', function(done){
+        var buf = new Buffer(1028)
+        var wasCalled = false
+        var limit = '1kb'
+        var server = createServer({ limit: function(req, res){
+          assert.equal(req.url, '/')
+          assert.ok(!res.headersSent)
+          wasCalled = true
+          return limit
+        }})
+
+        buf.fill('.')
+
+        // block with limit of 1kb
+        var test = request(server).post('/')
+        test.set('Content-Type', 'application/x-www-form-urlencoded')
+        test.send('str=' + buf.toString())
+        test.expect(413, function (err) {
+          assert.ifError(err)
+          assert.ok(wasCalled)
+
+          // pass with limit of 2kb
+          wasCalled = false
+          limit = '2kb'
+          var test = request(server).post('/')
+          test.set('Content-Type', 'application/x-www-form-urlencoded')
+          test.send('str=' + buf.toString())
+          test.expect(function () {
+            assert.ok(wasCalled)
+          })
+          test.expect(200, done)
+        })
+      })
+    })
   })
 
   describe('with parameterLimit option', function () {


### PR DESCRIPTION
This allows one to adjust the body size limit per-request, for example:

```js
app.use(bodyParser.json({limit: function (req, res) {
    if (req.url === '/import_something_huge') return '1mb'
    // uses default for everything else
}))
```

In our use case, we have an endpoint that imports a big (>100kb) chunk of data at once.
We've simply increased the limit for all requests for now, but I think it would be better if only the limit for that url was increased.

As far as I understand, the limit feature is here for security reasons (avoid DoS). And from the security point of view, there is no difference between increasing the limit of 1 endpoint or all them, since an attacker will try to exploit the weakest path. So this PR does not aim at increasing security, but it can't hurt it either.

What do you think?

PS: This PR does not update the docs, I just want to start the discussion around this idea, with some initial guess.