### PR TITLE
options.type accepts array

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,12 +90,13 @@ accept anything `JSON.parse` accepts. Defaults to `true`.
 ##### type
 
 The `type` option is used to determine what media type the middleware will
-parse. This option can be a function or a string. If a string, `type` option
-is passed directly to the [type-is](https://www.npmjs.org/package/type-is#readme)
-library and this can be an extension name (like `json`), a mime type (like
-`application/json`), or a mime type with a wildcard (like `*/*` or `*/json`).
-If a function, the `type` option is called as `fn(req)` and the request is
-parsed if it returns a truthy value. Defaults to `application/json`.
+parse. This option can be a string, array of strings, or a function. If it
+is a string or array of strings, `type` option is passed directly to the
+[type-is](https://www.npmjs.org/package/type-is#readme) library and this can
+be an extension name (like `json`), a mime type (like `application/json`), or
+a mime type with a wildcard (like `*/*` or `*/json`). If a function, the `type`
+option is called as `fn(req)` and the request is parsed if it returns a truthy
+value. Defaults to `application/json`.
 
 ##### verify
 

--- a/test/json.js
+++ b/test/json.js
@@ -271,6 +271,37 @@ describe('bodyParser.json()', function(){
       })
     })
 
+    describe('when an array of strings', function () {
+      var server
+      before(function () {
+        server = createServer({ type: ['application/json', 'application/vnd.api+json'] })
+      })
+
+      it('should parse JSON for the first type', function (done) {
+        request(server)
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .send('{"user":"tobi"}')
+        .expect(200, '{"user":"tobi"}', done)
+      })
+
+      it('should parse JSON for the second type', function (done) {
+        request(server)
+        .post('/')
+        .set('Content-Type', 'application/vnd.api+json')
+        .send('{"user":"tobi"}')
+        .expect(200, '{"user":"tobi"}', done)
+      })
+
+      it('should ignore other types', function (done) {
+        request(server)
+        .post('/')
+        .set('Content-Type', 'my/json')
+        .send('{"user":"tobi"}')
+        .expect(200, '{}', done)
+      })
+    })
+
     describe('when a function', function () {
       it('should parse when truthy value returned', function (done) {
         var server = createServer({ type: accept })


### PR DESCRIPTION
Seems like your type property in options correctly passes an array on to type-is. Wasn't immediately obvious I could do that based on the README.

- I'm guessing other parsers should be able to do this (didn't change those)
- Not sure if the tests are needed as this seems to be a function of type-is. 