### PR TITLE
json: update parse throw message to support node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ node_js:
   - "3.3"
   - "4.4"
   - "5.8"
+  - "6.0"
 sudo: false
 before_install:
   # Setup Node.js version-specific dependencies

--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -77,10 +77,13 @@ function json(options) {
 
     if (strict) {
       var first = firstchar(body)
-
+      var message = 'Unexpected token ' + first
       if (first !== '{' && first !== '[') {
+        if (process.version[1] >= 6) {
+          message += ' in JSON at position ' + (body.search(first) + 1)
+        }
         debug('strict violation')
-        throw new SyntaxError('Unexpected token ' + first)
+        throw new SyntaxError(message)
       }
     }
 

--- a/test/json.js
+++ b/test/json.js
@@ -23,7 +23,7 @@ describe('bodyParser.json()', function(){
     .post('/')
     .set('Content-Type', 'application/json')
     .send('{"user"')
-    .expect(400, 'Unexpected end of input', done)
+    .expect(400, /^Unexpected end of( JSON)? input/, done)
   })
 
   it('should handle Content-Length: 0', function(done){
@@ -62,8 +62,8 @@ describe('bodyParser.json()', function(){
     request(server)
     .post('/')
     .set('Content-Type', 'application/json')
-    .send('{:')
-    .expect(400, 'Unexpected token :', done);
+    .send(' {:')
+    .expect(400, /^Unexpected token :\s?(in JSON at position 2)?$/, done);
   })
 
   it('should 400 when invalid content-length', function(done){
@@ -117,8 +117,8 @@ describe('bodyParser.json()', function(){
       request(server)
       .post('/')
       .set('Content-Type', 'application/json')
-      .send('true')
-      .expect(400, 'Unexpected token t', done)
+      .send('    true')
+      .expect(400, /^Unexpected token t\s?(in JSON at position 5)?$/, done);
     })
 
     it('should allow leading whitespaces in JSON', function(done){
@@ -138,7 +138,7 @@ describe('bodyParser.json()', function(){
       .post('/')
       .set('Content-Type', 'application/json')
       .send('true')
-      .expect(400, 'Unexpected token t', done);
+      .expect(400, /^Unexpected token t\s?(in JSON at position 1)?/, done);
     })
   })
 


### PR DESCRIPTION
Node v6 has some updated error messages. This commit allows the parse function to throw the correct error message for the appropriate version of node. It also updates the unit tests to check to using regular
expressions instead of strings in order to support the new error messages while remaining backwards compatible.

fixes #167