### PR TITLE
Accept charset like utf8, UTF8 and UTF-8

### DIFF
--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -97,7 +97,8 @@ function urlencoded(options) {
 
     // assert charset
     var charset = getCharset(req) || 'utf-8'
-    if (charset !== 'utf-8') {
+
+    if (charset.toLowerCase() !== 'utf-8' && charset.toLowerCase() !== "utf8") {
       debug('invalid charset')
       next(createError(415, 'unsupported charset "' + charset.toUpperCase() + '"', {
         charset: charset


### PR DESCRIPTION
Some clients use http header "Accept-Charset: utf8" instead of "utf-8". This simple hack consider them as valid.
