### PR TITLE
Support for OMA (Open Mobile Alliance) protocol special Content-Type

### DIFF
--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -56,7 +56,7 @@ function json (options) {
   var inflate = opts.inflate !== false
   var reviver = opts.reviver
   var strict = opts.strict !== false
-  var type = opts.type || 'application/json'
+  var type = opts.type || ['application/json', 'application/vnd.oma.dm.initiation+json']
   var verify = opts.verify || false
 
   if (verify !== false && typeof verify !== 'function') {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "body-parser",
   "description": "Node.js body parsing middleware",
-  "version": "1.15.2",
+  "version": "1.15.3",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",
-    "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)"
+    "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)",
+    "Mike Barlow <barlowm@gmail.com>"
   ],
   "license": "MIT",
   "repository": "expressjs/body-parser",


### PR DESCRIPTION
I'm working on a server project for the OMA protocol which requires a content-type of:
'application/vnd.oma.dm.initiation+json'
Since the data being sent for this content-type is straight JSON data I just needed to do a simple add of the new content type to the json.js file.
Can I get this added to the master repo so I (and others working on OMA projects) can make use of this feature?

I added the changes to the package.json file for my own version of this code for my current project.

Thanks