### PR TITLE
Attribute nesting

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,13 +264,6 @@ The `verify` option, if supplied, is called as `verify(req, res, buf, encoding)`
 where `buf` is a `Buffer` of the raw request body and `encoding` is the
 encoding of the request. The parsing can be aborted by throwing an error.
 
-
-
-
-
-
-
-
 ### bodyParser.nested(options)
 
 Returns middleware that only parses `nested` bodies.
@@ -371,6 +364,31 @@ app.use(function (req, res) {
   res.setHeader('Content-Type', 'text/plain')
   res.write('you posted:\n')
   res.end(JSON.stringify(req.body, null, 2))
+})
+```
+
+### Express nested
+
+This example demonstrates the use of nesting, ie when submitted `user.name`.
+With nesting `req.body.user.name`; without nesting would be `req.body['user.name']`.
+
+```js
+var express = require('express')
+var bodyParser = require('body-parser')
+
+var app = express()
+
+// parse application/x-www-form-urlencoded
+app.use(bodyParser.urlencoded({ extended: false }))
+
+// parse application/json
+app.use(bodyParser.json())
+
+// parse nested
+app.use(bodyParser.nested())
+
+app.use(function (req, res) {
+  res.send('welcome, ' + req.body.user.name)
 })
 ```
 

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ var parsers = Object.create(null)
  * @property {function} raw
  * @property {function} text
  * @property {function} urlencoded
+ * @property {function} nested
  */
 
 /**
@@ -79,6 +80,17 @@ Object.defineProperty(exports, 'urlencoded', {
   configurable: true,
   enumerable: true,
   get: createParserGetter('urlencoded')
+})
+
+/**
+ * Nested parser.
+ * @public
+ */
+
+Object.defineProperty(exports, 'nested', {
+  configurable: true,
+  enumerable: true,
+  get: createParserGetter('nested')
 })
 
 /**
@@ -149,6 +161,9 @@ function loadParser (parserName) {
       break
     case 'urlencoded':
       parser = require('./lib/types/urlencoded')
+      break
+    case 'nested':
+      parser = require('./lib/types/nested')
       break
   }
 

--- a/lib/types/nested.js
+++ b/lib/types/nested.js
@@ -1,0 +1,100 @@
+/*!
+ * body-parser
+ * Copyright(c) 2016 Daniel Röhers Moura
+ * MIT Licensed
+ */
+
+'use strict'
+
+/**
+* Module exports.
+*/
+
+module.exports = nested
+
+/**
+ * Create a middleware to parse nested bodies.
+ *
+ * @param {object} [options]
+ * @return {function}
+ * @api public
+ */
+
+function nested (options) {
+  var opts = { body: true, query: true }
+  opts = Object.assign(opts, options)
+  return function nestedParser (req, res, next) {
+    if (opts.body && req.body) req.body = parse(req.body)
+    if (opts.query && req.query) req.query = parse(req.query)
+    next()
+  }
+};
+
+/**
+ * Parse nested bodies.
+ *
+ * @param {object} [object]
+ * @return {object}
+ * @api private
+ */
+
+function parse (object) {
+  object = object || {}
+  var result = {}
+  Object.keys(object).forEach(function (key) {
+    var list = splitKey(key)
+    var parsed = toObject(list, object[key])
+    result = merge(result, parsed)
+  })
+  return result
+};
+
+/**
+ * Split object key.
+ *
+ * @param {string} key
+ * @return {array}
+ * @api private
+ */
+
+function splitKey (key) {
+  return key.split('.')
+}
+
+/**
+ * Mount list on object.
+ *
+ * @param {array} list
+ * @param {*} value
+ * @return {object}
+ * @api private
+ */
+
+function toObject (list, value) {
+  var first = true
+  var object
+  for (var i = list.length - 1, l = 0; i >= l; i--) {
+    var temp = {}
+    var key = list[i]
+    temp[key] = first ? value : object
+    first = false
+    object = temp
+  }
+  return object
+}
+
+/**
+ * Merge objects.
+ *
+ * @param {object} object
+ * @param {object} parsed
+ * @return {object}
+ * @api private
+ */
+
+function merge (object, parsed) {
+  for (var key in parsed) {
+    object[key] = object[key] ? merge(object[key], parsed[key]) : parsed[key]
+  }
+  return object
+}

--- a/lib/types/nested.js
+++ b/lib/types/nested.js
@@ -7,8 +7,8 @@
 'use strict'
 
 /**
-* Module exports.
-*/
+ * Module exports.
+ */
 
 module.exports = nested
 
@@ -93,8 +93,26 @@ function toObject (list, value) {
  */
 
 function merge (object, parsed) {
+  if (!isObject(parsed)) {
+    object = parsed
+    return object
+  }
   for (var key in parsed) {
-    object[key] = object[key] ? merge(object[key], parsed[key]) : parsed[key]
+    var parent = object[key]
+    if (parent && !isObject(parent)) parent = {}
+    object[key] = parent ? merge(parent, parsed[key]) : parsed[key]
   }
   return object
+}
+
+/**
+ * Test object.
+ *
+ * @param {*} attr
+ * @return {boolean}
+ * @api private
+ */
+
+function isObject (attr) {
+  return typeof attr === 'object'
 }


### PR DESCRIPTION
Added option to perform attribute nesting on `req.body` or `req.query`.
If you have submitted `user.first_name` and `user.last_name`, an object is created.

Current:
```js
  req.body['user.first_name'] = 'daniel';
  req.body['user.last_name'] = 'moura';
```

New:

```js
  req.body.user.first_name = 'daniel';
  req.body.user.last_name = 'moura';
```
