### PR TITLE
test: Made unit test passing with node-chakracore

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,13 @@ node_js:
   - "6.11"
   - "7.10"
   - "8.4"
+matrix:
+  include:
+    - node_js: "8.4"
+      env: "NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/chakracore-release/"
+  allow_failures:
+    # Allow chakracore to fail
+    - env: "NVM_NODEJS_ORG_MIRROR=https://nodejs.org/download/chakracore-release/"
 sudo: false
 cache:
   directories:


### PR DESCRIPTION
There were 3 unit test that were failing with node-chakracore because of error message difference between v8 and chakracore. Added logic to generate error on fly and use that to compare the error message.

For `should parse deep object` test case, chakracore throws `Out of stack` for size `500` depth. v8 throws after `800` limit and the variation is because different size for stack probing. Restricted the depth to `250` which should be good enough to validate the depth and not throw.

Ref: nodejs/node-chakracore#189