### PR TITLE
Avoid `throw` for an acceptable situation

### DIFF
--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -154,7 +154,7 @@ function firstchar (str) {
 
 function getCharset (req) {
   try {
-    let charset = contentType.parse(req).parameters.charset;
+    var charset = contentType.parse(req).parameters.charset;
     return charset ? charset.toLowerCase() : undefined;
   } catch (e) {
     return undefined

--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -154,7 +154,8 @@ function firstchar (str) {
 
 function getCharset (req) {
   try {
-    return contentType.parse(req).parameters.charset.toLowerCase()
+    let charset = contentType.parse(req).parameters.charset;
+    return charset ? charset.toLowerCase() : undefined;
   } catch (e) {
     return undefined
   }


### PR DESCRIPTION
When debugging and breaking on all exceptions, this one kept tripping because there is no charset parameter for my requests (for some reason) which seems reasonable.  Prechecks for that case and avoids the throw, still returning undefined as it would have.