### PR TITLE
Allow user to pass extra options to `qs` parser

### DIFF
--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -156,12 +156,12 @@ function extendedparser (options) {
     var arrayLimit = Math.max(100, paramCount)
 
     debug('parse extended urlencoding')
-    return parse(body, {
+    return parse(body, Object.assign({
       allowPrototypes: true,
       arrayLimit: arrayLimit,
       depth: Infinity,
       parameterLimit: parameterLimit
-    })
+    }, options))
   }
 }
 


### PR DESCRIPTION
Allow user to pass extra options to `qs` parser, like `parseArrays` option