### PR TITLE
options.type accepts array

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ to `'100kb'`.
 
 The `reviver` option is passed directly to `JSON.parse` as the second
 argument. You can find more information on this argument
-[in the MDN documentation about JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter).
+[in the MDN documentation about
+JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter).
 
 ##### strict
 
@@ -133,9 +134,10 @@ to `'100kb'`.
 ##### type
 
 The `type` option is used to determine what media type the middleware will
-parse. This option can be a string, array of strings, or a function. If it is a string or array of strings, `type` option
-is passed directly to the [type-is](https://www.npmjs.org/package/type-is#readme)
-library and this can be an extension name (like `bin`), a mime type (like
+parse. This option can be a string, array of strings, or a function.
+If it is a string or array of strings, `type` option is passed directly to
+the [type-is](https://www.npmjs.org/package/type-is#readme) library and this can be an extension
+name (like `bin`), a mime type (like
 `application/octet-stream`), or a mime type with a wildcard (like `*/*` or
 `application/*`). If a function, the `type` option is called as `fn(req)`
 and the request is parsed if it returns a truthy value. Defaults to
@@ -181,7 +183,8 @@ to `'100kb'`.
 ##### type
 
 The `type` option is used to determine what media type the middleware will
-parse. This option can be a string, array of strings, or a function. If it is a string or array of strings, `type` option
+parse. This option can be a string, array of strings, or a function. If it is a string or array of
+strings, `type` option
 is passed directly to the [type-is](https://www.npmjs.org/package/type-is#readme)
 library and this can be an extension name (like `txt`), a mime type (like
 `text/plain`), or a mime type with a wildcard (like `*/*` or `text/*`).
@@ -244,7 +247,8 @@ than this value, a 413 will be returned to the client. Defaults to `1000`.
 ##### type
 
 The `type` option is used to determine what media type the middleware will
-parse. This option can be a string, array of strings, or a function. If it is a string or array of strings, `type` option
+parse. This option can be a string, array of strings, or a function. If it is a string or array of
+strings, `type` option
 is passed directly to the [type-is](https://www.npmjs.org/package/type-is#readme)
 library and this can be an extension name (like `urlencoded`), a mime type (like
 `application/x-www-form-urlencoded`), or a mime type with a wildcard (like

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ to `'100kb'`.
 ##### type
 
 The `type` option is used to determine what media type the middleware will
-parse. This option can be a function or a string. If a string, `type` option
+parse. This option can be a string, array of strings, or a function. If it is a string or array of strings, `type` option
 is passed directly to the [type-is](https://www.npmjs.org/package/type-is#readme)
 library and this can be an extension name (like `bin`), a mime type (like
 `application/octet-stream`), or a mime type with a wildcard (like `*/*` or
@@ -181,7 +181,7 @@ to `'100kb'`.
 ##### type
 
 The `type` option is used to determine what media type the middleware will
-parse. This option can be a function or a string. If a string, `type` option
+parse. This option can be a string, array of strings, or a function. If it is a string or array of strings, `type` option
 is passed directly to the [type-is](https://www.npmjs.org/package/type-is#readme)
 library and this can be an extension name (like `txt`), a mime type (like
 `text/plain`), or a mime type with a wildcard (like `*/*` or `text/*`).
@@ -244,7 +244,7 @@ than this value, a 413 will be returned to the client. Defaults to `1000`.
 ##### type
 
 The `type` option is used to determine what media type the middleware will
-parse. This option can be a function or a string. If a string, `type` option
+parse. This option can be a string, array of strings, or a function. If it is a string or array of strings, `type` option
 is passed directly to the [type-is](https://www.npmjs.org/package/type-is#readme)
 library and this can be an extension name (like `urlencoded`), a mime type (like
 `application/x-www-form-urlencoded`), or a mime type with a wildcard (like

--- a/README.md
+++ b/README.md
@@ -90,12 +90,13 @@ accept anything `JSON.parse` accepts. Defaults to `true`.
 ##### type
 
 The `type` option is used to determine what media type the middleware will
-parse. This option can be a function or a string. If a string, `type` option
-is passed directly to the [type-is](https://www.npmjs.org/package/type-is#readme)
-library and this can be an extension name (like `json`), a mime type (like
-`application/json`), or a mime type with a wildcard (like `*/*` or `*/json`).
-If a function, the `type` option is called as `fn(req)` and the request is
-parsed if it returns a truthy value. Defaults to `application/json`.
+parse. This option can be a string, array of strings, or a function. If it
+is a string or array of strings, `type` option is passed directly to the
+[type-is](https://www.npmjs.org/package/type-is#readme) library and this can
+be an extension name (like `json`), a mime type (like `application/json`), or
+a mime type with a wildcard (like `*/*` or `*/json`). If a function, the `type`
+option is called as `fn(req)` and the request is parsed if it returns a truthy
+value. Defaults to `application/json`.
 
 ##### verify
 

--- a/test/json.js
+++ b/test/json.js
@@ -271,6 +271,37 @@ describe('bodyParser.json()', function(){
       })
     })
 
+    describe('when an array of strings', function () {
+      var server
+      before(function () {
+        server = createServer({ type: ['application/json', 'application/vnd.api+json'] })
+      })
+
+      it('should parse JSON for the first type', function (done) {
+        request(server)
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .send('{"user":"tobi"}')
+        .expect(200, '{"user":"tobi"}', done)
+      })
+
+      it('should parse JSON for the second type', function (done) {
+        request(server)
+        .post('/')
+        .set('Content-Type', 'application/vnd.api+json')
+        .send('{"user":"tobi"}')
+        .expect(200, '{"user":"tobi"}', done)
+      })
+
+      it('should ignore other types', function (done) {
+        request(server)
+        .post('/')
+        .set('Content-Type', 'my/json')
+        .send('{"user":"tobi"}')
+        .expect(200, '{}', done)
+      })
+    })
+
     describe('when a function', function () {
       it('should parse when truthy value returned', function (done) {
         var server = createServer({ type: accept })

--- a/test/raw.js
+++ b/test/raw.js
@@ -188,6 +188,34 @@ describe('bodyParser.raw()', function(){
       })
     })
 
+    describe('when an array of strings', function () {
+      var server
+      before(function () {
+        server = createServer({ type: ['application/octet-stream', 'application/vnd+octets'] })
+      })
+
+      it('should parse for the first type', function (done) {
+        var test = request(server).post('/')
+        test.set('Content-Type', 'application/octet-stream')
+        test.write(new Buffer('000102', 'hex'))
+        test.expect(200, 'buf:000102', done)
+      })
+
+      it('should parse for the second type', function (done) {
+        var test = request(server).post('/')
+        test.set('Content-Type', 'application/vnd+octets')
+        test.write(new Buffer('000102', 'hex'))
+        test.expect(200, 'buf:000102', done)
+      })
+
+      it('should ignore other types', function (done) {
+        var test = request(server).post('/')
+        test.set('Content-Type', 'my/raw')
+        test.write(new Buffer('000102', 'hex'))
+        test.expect(200, '{}', done)
+      })
+    })
+
     describe('when a function', function () {
       it('should parse when truthy value returned', function (done) {
         var server = createServer({ type: accept })

--- a/test/text.js
+++ b/test/text.js
@@ -226,7 +226,7 @@ describe('bodyParser.text()', function(){
         .post('/')
         .set('Content-Type', 'text/html')
         .send('<b>tobi</b>')
-        .expect(200, '<b>tobi</b>', done)
+        .expect(200, '"<b>tobi</b>"', done)
       })
 
       it('should parse for the second type', function (done) {
@@ -234,7 +234,7 @@ describe('bodyParser.text()', function(){
         .post('/')
         .set('Content-Type', 'text/plain')
         .send('user is tobi')
-        .expect(200, 'user is tobi', done)
+        .expect(200, '"user is tobi"', done)
       })
 
       it('should ignore other types', function (done) {

--- a/test/text.js
+++ b/test/text.js
@@ -215,6 +215,37 @@ describe('bodyParser.text()', function(){
       })
     })
 
+    describe('when an array of strings', function () {
+      var server
+      before(function () {
+        server = createServer({ type: ['text/html', 'text/plain'] })
+      })
+
+      it('should parse for the first type', function (done) {
+        request(server)
+        .post('/')
+        .set('Content-Type', 'text/html')
+        .send('<b>tobi</b>')
+        .expect(200, '<b>tobi</b>', done)
+      })
+
+      it('should parse for the second type', function (done) {
+        request(server)
+        .post('/')
+        .set('Content-Type', 'text/plain')
+        .send('user is tobi')
+        .expect(200, 'user is tobi', done)
+      })
+
+      it('should ignore other types', function (done) {
+        request(server)
+        .post('/')
+        .set('Content-Type', 'my/text')
+        .send('user is tobi')
+        .expect(200, '{}', done)
+      })
+    })
+
     describe('when a function', function () {
       it('should parse when truthy value returned', function (done) {
         var server = createServer({ type: accept })

--- a/test/urlencoded.js
+++ b/test/urlencoded.js
@@ -439,6 +439,37 @@ describe('bodyParser.urlencoded()', function(){
       })
     })
 
+    describe('when an array of strings', function () {
+      var server
+      before(function () {
+        server = createServer({ type: ['application/vnd.x-www-form-urlencoded', 'application/x-www-form-urlencoded'] })
+      })
+
+      it('should parse for the first type', function (done) {
+        request(server)
+        .post('/')
+        .set('Content-Type', 'application/vnd.x-www-form-urlencoded')
+        .send('user=tobi')
+        .expect(200, '{"user":"tobi"}', done)
+      })
+
+      it('should parse for the second type', function (done) {
+        request(server)
+        .post('/')
+        .set('Content-Type', 'application/x-www-form-urlencoded')
+        .send('user=tobi')
+        .expect(200, '{"user":"tobi"}', done)
+      })
+
+      it('should ignore other types', function (done) {
+        request(server)
+        .post('/')
+        .set('Content-Type', 'my/urlencoded')
+        .send('user=tobi')
+        .expect(200, '{}', done)
+      })
+    })
+
     describe('when a function', function () {
       it('should parse when truthy value returned', function (done) {
         var server = createServer({ type: accept })


### PR DESCRIPTION
I just forked an existing PR and added what was missing for it to be merged. See [the original conversation](https://github.com/expressjs/body-parser/pull/163).

Summary:
**heme:**

> Seems like your type property in options correctly passes an array on to type-is. Wasn't immediately obvious I could do that based on the README.

**dougwilson:**

> Awesome, thanks! Can you go ahead and also add it to all the other parsers as well? Currently I believe all their type sections are identical, so let's keep them identical.

So that's what I did. Added the change to all the other parsers as well :)