### PR TITLE
WIP Add way to reject body with the wrong content type

### DIFF
--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -57,6 +57,7 @@ function json (options) {
   var reviver = opts.reviver
   var strict = opts.strict !== false
   var type = opts.type || 'application/json'
+  var strictType = !!opts.strictType
   var verify = opts.verify || false
 
   if (verify !== false && typeof verify !== 'function') {
@@ -114,6 +115,14 @@ function json (options) {
 
     // determine if request should be parsed
     if (!shouldParse(req)) {
+      if (strictType) {
+        debug('invalid content-type')
+        next(createError(415, 'Unsupported Content-Type: "' + req.headers['content-type'] + '"', {
+          // charset: charset,
+          type: 'content-type.unsupported'
+        }))
+      }
+
       debug('skip parsing')
       next()
       return

--- a/test/json.js
+++ b/test/json.js
@@ -372,6 +372,20 @@ describe('bodyParser.json()', function () {
     })
   })
 
+  describe('with strictType option', function () {
+    before(function () {
+      this.server = createServer({ strictType: true })
+    })
+
+    it('should error when given wrong content type', function (done) {
+      request(this.server)
+      .post('/')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send('')
+      .expect(415, 'Unsupported Content-Type: "application/x-www-form-urlencoded"', done)
+    })
+  })
+
   describe('with verify option', function () {
     it('should assert value if function', function () {
       assert.throws(createServer.bind(null, { verify: 'lol' }),


### PR DESCRIPTION
I was messing around with an Express route I had `bodyParser.json()` on, and kind of assumed that if I gave it a random POST, it would fail. But after reading the README again, the way Body Parser works makes sense. I started to think about writing this logic apart, but it seemed really closely coupled to the logic of Body Parser, so I looked adding this.

I started off writing this as an issue but I figure a diff would help illustrate the idea a lot better.

This adds a new `strictType` option. It's false by default, but when enabled, it fails requests with a [**HTTP 415 Unsupported Media Type**](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/415) error

* [ ] copy edits
* [ ] README
* [ ] add the same option to the other types