### PR TITLE
Added support for external parsers to bodyParser.json()

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,16 @@ The `verify` option, if supplied, is called as `verify(req, res, buf, encoding)`
 where `buf` is a `Buffer` of the raw request body and `encoding` is the
 encoding of the request. The parsing can be aborted by throwing an error.
 
+##### parser
+
+The `parser` option, if supplied, is used to in place of the default parser to
+convert the request body into a Javascript object. If this option is supplied,
+both the `extended` and `parameterLimit` options are ignored.
+
+```javascript
+parser(body) -> req.body
+```
+
 ## Errors
 
 The middlewares provided by this module create errors depending on the error

--- a/README.md
+++ b/README.md
@@ -89,12 +89,18 @@ to `'100kb'`.
 ##### parser
 
 The `parser` option is the function called against the request body to convert
-it to a Javascript object. Defaults to `JSON.parse`.
+it to a Javascript object. If a `reviver` is supplied, it is supplied as the
+second argument to this function.
+
+```javascript
+parser(body, reviver) -> req.body
+```
+
+Defaults to `JSON.parse`.
 
 ##### reviver
 
-The `reviver` option is passed directly to the `parser` as the second
-argument. You can find more information on this argument
+You can find more information on this argument
 [in the MDN documentation about JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter).
 
 ##### strict

--- a/README.md
+++ b/README.md
@@ -170,6 +170,15 @@ The `verify` option, if supplied, is called as `verify(req, res, buf, encoding)`
 where `buf` is a `Buffer` of the raw request body and `encoding` is the
 encoding of the request. The parsing can be aborted by throwing an error.
 
+##### parser
+
+The `parser` option, if supplied, is used to transform the body of a request
+before being set to `req.body`.
+
+```javascript
+parser(body) -> req.body
+```
+
 ### bodyParser.text([options])
 
 Returns middleware that parses all bodies as a string and only looks at

--- a/README.md
+++ b/README.md
@@ -219,6 +219,15 @@ The `verify` option, if supplied, is called as `verify(req, res, buf, encoding)`
 where `buf` is a `Buffer` of the raw request body and `encoding` is the
 encoding of the request. The parsing can be aborted by throwing an error.
 
+##### parser
+
+The `parser` option, if supplied, is used to transform the body of a request
+before being set to `req.body`.
+
+```javascript
+parser(body) -> req.body
+```
+
 ### bodyParser.urlencoded([options])
 
 Returns middleware that only parses `urlencoded` bodies and only looks at

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The `parser` option is the function called against the request body to convert
 it to a Javascript object. If a `reviver` is supplied, it is supplied as the
 second argument to this function.
 
-```javascript
+```
 parser(body, reviver) -> req.body
 ```
 
@@ -175,7 +175,7 @@ encoding of the request. The parsing can be aborted by throwing an error.
 The `parser` option, if supplied, is used to transform the body of a request
 before being set to `req.body`.
 
-```javascript
+```
 parser(body) -> req.body
 ```
 
@@ -233,7 +233,7 @@ encoding of the request. The parsing can be aborted by throwing an error.
 The `parser` option, if supplied, is used to transform the body of a request
 before being set to `req.body`.
 
-```javascript
+```
 parser(body) -> req.body
 ```
 
@@ -309,7 +309,7 @@ The `parser` option, if supplied, is used to in place of the default parser to
 convert the request body into a Javascript object. If this option is supplied,
 both the `extended` and `parameterLimit` options are ignored.
 
-```javascript
+```
 parser(body) -> req.body
 ```
 

--- a/README.md
+++ b/README.md
@@ -86,16 +86,21 @@ specifies the number of bytes; if it is a string, the value is passed to the
 [bytes](https://www.npmjs.com/package/bytes) library for parsing. Defaults
 to `'100kb'`.
 
+##### parser
+
+The `parser` option is the function called against the request body to convert
+it to a Javascript object. Defaults to `JSON.parse`.
+
 ##### reviver
 
-The `reviver` option is passed directly to `JSON.parse` as the second
+The `reviver` option is passed directly to the `parser` as the second
 argument. You can find more information on this argument
 [in the MDN documentation about JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter).
 
 ##### strict
 
 When set to `true`, will only accept arrays and objects; when `false` will
-accept anything `JSON.parse` accepts. Defaults to `true`.
+accept anything the `parser` accepts. Defaults to `true`.
 
 ##### type
 

--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -81,7 +81,7 @@ function json (options) {
 
       if (first !== '{' && first !== '[') {
         debug('strict violation')
-        throw createStrictSyntaxError(parser, body, first)
+        throw createStrictSyntaxError(parser, reviver, body, first)
       }
     }
 
@@ -150,12 +150,12 @@ function json (options) {
  * @private
  */
 
-function createStrictSyntaxError (parser, str, char) {
+function createStrictSyntaxError (parser, reviver, str, char) {
   var index = str.indexOf(char)
   var partial = str.substring(0, index) + '#'
 
   try {
-    parser(partial); /* istanbul ignore next */ throw new SyntaxError('strict violation')
+    parser(partial, reviver); /* istanbul ignore next */ throw new SyntaxError('strict violation')
   } catch (e) {
     return normalizeJsonSyntaxError(e, {
       message: e.message.replace('#', char),

--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -58,6 +58,7 @@ function json (options) {
   var strict = opts.strict !== false
   var type = opts.type || 'application/json'
   var verify = opts.verify || false
+  var parser = opts.parser || JSON.parse
 
   if (verify !== false && typeof verify !== 'function') {
     throw new TypeError('option verify must be function')
@@ -80,13 +81,13 @@ function json (options) {
 
       if (first !== '{' && first !== '[') {
         debug('strict violation')
-        throw createStrictSyntaxError(body, first)
+        throw createStrictSyntaxError(parser, body, first)
       }
     }
 
     try {
       debug('parse json')
-      return JSON.parse(body, reviver)
+      return parser(body, reviver)
     } catch (e) {
       throw normalizeJsonSyntaxError(e, {
         stack: e.stack
@@ -149,12 +150,12 @@ function json (options) {
  * @private
  */
 
-function createStrictSyntaxError (str, char) {
+function createStrictSyntaxError (parser, str, char) {
   var index = str.indexOf(char)
   var partial = str.substring(0, index) + '#'
 
   try {
-    JSON.parse(partial); /* istanbul ignore next */ throw new SyntaxError('strict violation')
+    parser(partial); /* istanbul ignore next */ throw new SyntaxError('strict violation')
   } catch (e) {
     return normalizeJsonSyntaxError(e, {
       message: e.message.replace('#', char),

--- a/lib/types/raw.js
+++ b/lib/types/raw.js
@@ -89,7 +89,7 @@ function raw (options) {
 }
 
 function defaultParser (buf) {
-  return buf;
+  return buf
 }
 
 /**

--- a/lib/types/raw.js
+++ b/lib/types/raw.js
@@ -38,6 +38,7 @@ function raw (options) {
     : opts.limit
   var type = opts.type || 'application/octet-stream'
   var verify = opts.verify || false
+  var parser = opts.parser || defaultParser
 
   if (verify !== false && typeof verify !== 'function') {
     throw new TypeError('option verify must be function')
@@ -49,7 +50,7 @@ function raw (options) {
     : type
 
   function parse (buf) {
-    return buf
+    return parser(buf)
   }
 
   return function rawParser (req, res, next) {
@@ -85,6 +86,10 @@ function raw (options) {
       verify: verify
     })
   }
+}
+
+function defaultParser (buf) {
+  return buf;
 }
 
 /**

--- a/lib/types/text.js
+++ b/lib/types/text.js
@@ -40,6 +40,7 @@ function text (options) {
     : opts.limit
   var type = opts.type || 'text/plain'
   var verify = opts.verify || false
+  var parser = opts.parser || defaultParser
 
   if (verify !== false && typeof verify !== 'function') {
     throw new TypeError('option verify must be function')
@@ -51,7 +52,7 @@ function text (options) {
     : type
 
   function parse (buf) {
-    return buf
+    return parser(buf)
   }
 
   return function textParser (req, res, next) {
@@ -90,6 +91,10 @@ function text (options) {
       verify: verify
     })
   }
+}
+
+function defaultParser (buf) {
+  return buf;
 }
 
 /**

--- a/lib/types/text.js
+++ b/lib/types/text.js
@@ -94,7 +94,7 @@ function text (options) {
 }
 
 function defaultParser (buf) {
-  return buf;
+  return buf
 }
 
 /**

--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -44,7 +44,7 @@ function urlencoded (options) {
   var opts = options || {}
 
   // notice because option default will flip in next major
-  if (opts.extended === undefined) {
+  if (opts.extended === undefined && opts.parser === undefined) {
     deprecate('undefined extended: provide extended option')
   }
 
@@ -61,9 +61,11 @@ function urlencoded (options) {
   }
 
   // create the appropriate query parser
-  var queryparse = extended
+  var parser = opts.parser || (
+    extended
     ? extendedparser(opts)
     : simpleparser(opts)
+  )
 
   // create the appropriate type checking function
   var shouldParse = typeof type !== 'function'
@@ -72,7 +74,7 @@ function urlencoded (options) {
 
   function parse (body) {
     return body.length
-      ? queryparse(body)
+      ? parser(body)
       : {}
   }
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "eslint-plugin-promise": "3.5.0",
     "eslint-plugin-standard": "3.0.1",
     "istanbul": "0.4.5",
-    "json-bigint": "0.2.3",
     "methods": "1.1.2",
     "mocha": "2.5.3",
     "safe-buffer": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "eslint-plugin-promise": "3.5.0",
     "eslint-plugin-standard": "3.0.1",
     "istanbul": "0.4.5",
+    "json-bigint": "0.2.3",
     "methods": "1.1.2",
     "mocha": "2.5.3",
     "safe-buffer": "5.1.1",

--- a/test/json.js
+++ b/test/json.js
@@ -72,7 +72,7 @@ describe('bodyParser.json()', function () {
   it('should use external parsers', function (done) {
     request(createServer({
       parser: function (body) {
-        return { foo: "bar" }
+        return { foo: 'bar' }
       }
     }))
     .post('/')

--- a/test/json.js
+++ b/test/json.js
@@ -3,7 +3,6 @@ var assert = require('assert')
 var Buffer = require('safe-buffer').Buffer
 var http = require('http')
 var request = require('supertest')
-var JSONbig = require('json-bigint')
 
 var bodyParser = require('..')
 
@@ -72,12 +71,14 @@ describe('bodyParser.json()', function () {
 
   it('should use external parsers', function (done) {
     request(createServer({
-      parser: JSONbig({ storeAsString: true }).parse
+      parser: function (body) {
+        return { foo: "bar" }
+      }
     }))
     .post('/')
     .set('Content-Type', 'application/json')
-    .send('{"user_id":1234567890123456789012345678901234567890123456789012345678901234567890}')
-    .expect(200, '{"user_id":"1234567890123456789012345678901234567890123456789012345678901234567890"}', done)
+    .send('{"str":')
+    .expect(200, '{"foo":"bar"}', done)
   })
 
   describe('when JSON is invalid', function () {

--- a/test/json.js
+++ b/test/json.js
@@ -3,6 +3,7 @@ var assert = require('assert')
 var Buffer = require('safe-buffer').Buffer
 var http = require('http')
 var request = require('supertest')
+var JSONbig = require('json-bigint')
 
 var bodyParser = require('..')
 
@@ -67,6 +68,16 @@ describe('bodyParser.json()', function () {
     .set('Content-Type', 'application/json')
     .send('{"user":"tobi"}')
     .expect(200, '{"user":"tobi"}', done)
+  })
+
+  it('should use external parsers', function (done) {
+    request(createServer({
+      parser: JSONbig({ storeAsString: true }).parse
+    }))
+    .post('/')
+    .set('Content-Type', 'application/json')
+    .send('{"user_id":1234567890123456789012345678901234567890123456789012345678901234567890}')
+    .expect(200, '{"user_id":"1234567890123456789012345678901234567890123456789012345678901234567890"}', done)
   })
 
   describe('when JSON is invalid', function () {

--- a/test/raw.js
+++ b/test/raw.js
@@ -21,7 +21,7 @@ describe('bodyParser.raw()', function () {
 
   it('should parse application/octet-stream with a custom parser', function (done) {
     request(createServer({
-      parser: function (body) { return body.toString("utf8") }
+      parser: function (body) { return body.toString('utf8') }
     }))
     .post('/')
     .set('Content-Type', 'application/octet-stream')

--- a/test/raw.js
+++ b/test/raw.js
@@ -19,6 +19,16 @@ describe('bodyParser.raw()', function () {
     .expect(200, 'buf:746865207573657220697320746f6269', done)
   })
 
+  it('should parse application/octet-stream with a custom parser', function (done) {
+    request(createServer({
+      parser: function (body) { return body.toString("utf8") }
+    }))
+    .post('/')
+    .set('Content-Type', 'application/octet-stream')
+    .send('the user is tobi')
+    .expect(200, '"the user is tobi"', done)
+  })
+
   it('should 400 when invalid content-length', function (done) {
     var rawParser = bodyParser.raw()
     var server = createServer(function (req, res, next) {

--- a/test/text.js
+++ b/test/text.js
@@ -19,6 +19,16 @@ describe('bodyParser.text()', function () {
     .expect(200, '"user is tobi"', done)
   })
 
+  it('should parse text/plain with a custom parser', function (done) {
+    request(createServer({
+      parser: function (input) { return input.toUpperCase() }
+    }))
+    .post('/')
+    .set('Content-Type', 'text/plain')
+    .send('user is tobi')
+    .expect(200, '"USER IS TOBI"', done)
+  })
+
   it('should 400 when invalid content-length', function (done) {
     var textParser = bodyParser.text()
     var server = createServer(function (req, res, next) {

--- a/test/urlencoded.js
+++ b/test/urlencoded.js
@@ -19,6 +19,16 @@ describe('bodyParser.urlencoded()', function () {
     .expect(200, '{"user":"tobi"}', done)
   })
 
+  it('should parse x-www-form-urlencoded with custom parser', function (done) {
+    request(createServer({
+      parser: function (input) { return input.toUpperCase() }
+    }))
+    .post('/')
+    .set('Content-Type', 'application/x-www-form-urlencoded')
+    .send('user=tobi')
+    .expect(200, '"USER=TOBI"', done)
+  })
+
   it('should 400 when invalid content-length', function (done) {
     var urlencodedParser = bodyParser.urlencoded()
     var server = createServer(function (req, res, next) {


### PR DESCRIPTION
Added the option to use a function other than `JSON.parse` to do the actual parsing. This fixes #278; contrary to one of the suggestions in that issue I left the `reviver` option as-is for backward compatibility.  Also see #42, where adding a similar option for query string parsing was the preferred choice.