### PR TITLE
Add String or Number Only JSONString Support

### DIFF
--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -75,15 +75,6 @@ function json (options) {
       return {}
     }
 
-    if (strict) {
-      var first = firstchar(body)
-
-      if (first !== '{' && first !== '[') {
-        debug('strict violation')
-        throw createStrictSyntaxError(body, first)
-      }
-    }
-
     try {
       debug('parse json')
       return JSON.parse(body, reviver)


### PR DESCRIPTION
```javascript
JSON.parse(`"text"`) // "text"
JSON.parse(`123`) // 123
```