### PR TITLE
Support for checking empty JSON body.

### DIFF
--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -47,7 +47,7 @@ var FIRST_CHAR_REGEXP = /^[\x20\x09\x0a\x0d]*(.)/ // eslint-disable-line no-cont
  * @public
  */
 
-function json (options) {
+function json(options) {
   var opts = options || {}
 
   var limit = typeof opts.limit !== 'number'
@@ -68,26 +68,24 @@ function json (options) {
     ? typeChecker(type)
     : type
 
-  function parse (body) {
-    if (body.length === 0) {
-      // special-case empty json body, as it's a common client-side mistake
-      // TODO: maybe make this configurable or part of "strict" option
-      return {}
-    }
-
+  function parse(body) {
     if (strict) {
-      var first = firstchar(body)
-
-      if (first !== '{' && first !== '[') {
-        debug('strict violation')
-        throw createStrictSyntaxError(body, first)
-      }
       // BEGIN - Check empty body
       if (body.length === 0) {
         debug('strict violation')
         throw createEmptyBodyError()
       }
       // END - Check empty body
+
+      var first = firstchar(body)
+      if (first !== '{' && first !== '[') {
+        debug('strict violation')
+        throw createStrictSyntaxError(body, first)
+      }
+    } else {
+      if (body.length === 0) {
+        return {}
+      }
     }
 
     try {
@@ -101,7 +99,7 @@ function json (options) {
     }
   }
 
-  return function jsonParser (req, res, next) {
+  return function jsonParser(req, res, next) {
     if (req._body) {
       debug('body already parsed')
       next()
@@ -110,12 +108,15 @@ function json (options) {
 
     req.body = req.body || {}
 
+    // BEGIN - Check empty body
+    /* 
     // skip requests without bodies
     if (!typeis.hasBody(req)) {
       debug('skip empty body')
       next()
       return
-    }
+    } */
+    // END - Check empty body
 
     debug('content-type %j', req.headers['content-type'])
 
@@ -156,7 +157,7 @@ function json (options) {
  * @private
  */
 
-function createStrictSyntaxError (str, char) {
+function createStrictSyntaxError(str, char) {
   var index = str.indexOf(char)
   var partial = str.substring(0, index) + '#'
 
@@ -164,7 +165,7 @@ function createStrictSyntaxError (str, char) {
     JSON.parse(partial); /* istanbul ignore next */ throw new SyntaxError('strict violation')
   } catch (e) {
     return normalizeJsonSyntaxError(e, {
-      message: e.message.replace('#', char),
+      message: e.message.replace('#', char) + ' NS ',
       stack: e.stack
     })
   }
@@ -180,7 +181,7 @@ function createStrictSyntaxError (str, char) {
  */
 function createEmptyBodyError() {
   try {
-    throw err 
+    throw Error()
   } catch (e) {
     return normalizeJsonSyntaxError(e, {
       message: 'Empty JSON body received.',
@@ -197,7 +198,7 @@ function createEmptyBodyError() {
  * @private
  */
 
-function firstchar (str) {
+function firstchar(str) {
   return FIRST_CHAR_REGEXP.exec(str)[1]
 }
 
@@ -208,7 +209,7 @@ function firstchar (str) {
  * @api private
  */
 
-function getCharset (req) {
+function getCharset(req) {
   try {
     return (contentType.parse(req).parameters.charset || '').toLowerCase()
   } catch (e) {
@@ -224,7 +225,7 @@ function getCharset (req) {
  * @return {SyntaxError}
  */
 
-function normalizeJsonSyntaxError (error, obj) {
+function normalizeJsonSyntaxError(error, obj) {
   var keys = Object.getOwnPropertyNames(error)
 
   for (var i = 0; i < keys.length; i++) {
@@ -248,8 +249,8 @@ function normalizeJsonSyntaxError (error, obj) {
  * @return {function}
  */
 
-function typeChecker (type) {
-  return function checkType (req) {
+function typeChecker(type) {
+  return function checkType(req) {
     return Boolean(typeis(req, type))
   }
 }

--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -87,6 +87,7 @@ function json (options) {
         debug('strict violation')
         throw createEmptyBodyError()
       }
+      // END - Check empty body
     }
 
     try {

--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -82,6 +82,11 @@ function json (options) {
         debug('strict violation')
         throw createStrictSyntaxError(body, first)
       }
+      // BEGIN - Check empty body
+      if (body.length === 0) {
+        debug('strict violation')
+        throw createEmptyBodyError()
+      }
     }
 
     try {
@@ -159,6 +164,25 @@ function createStrictSyntaxError (str, char) {
   } catch (e) {
     return normalizeJsonSyntaxError(e, {
       message: e.message.replace('#', char),
+      stack: e.stack
+    })
+  }
+}
+
+/**
+ * Create empty violation syntax error matching native error.
+ *
+ * @param {string} str
+ * @param {string} char
+ * @return {Error}
+ * @private
+ */
+function createEmptyBodyError() {
+  try {
+    throw err 
+  } catch (e) {
+    return normalizeJsonSyntaxError(e, {
+      message: 'Empty JSON body received.',
       stack: e.stack
     })
   }

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "eslint-plugin-promise": "4.2.1",
     "eslint-plugin-standard": "4.0.0",
     "istanbul": "0.4.5",
-    "methods": "1.1.2",
+    "methods": "^1.1.2",
     "mocha": "6.1.4",
     "safe-buffer": "5.1.2",
-    "supertest": "4.0.2"
+    "supertest": "^4.0.2"
   },
   "files": [
     "lib/",


### PR DESCRIPTION
# Requirement
Let the JSON body parser package raise an error if the payload is empty. This middleware maybe added for certain `POST` or `PUT` requests.

## Solution
Check for an empty string and raise a new error named as `createEmptyBodyError` which is similar to `function createStrictSyntaxError` in `parse` function at [`lib/tpyes/json.js`](https://github.com/expressjs/body-parser/blob/b15bae549108e613ceb5e408731cbdb374ad62df/lib/types/json.js#L71). This is done when the option of strict checking is set to `true` - the default.

## Notes

1. When the body is empty, then `length` is not set correctly at [`lib/read.js`](https://github.com/expressjs/body-parser/blob/b15bae549108e613ceb5e408731cbdb374ad62df/lib/read.js#L146), if `Content-Length` is not passed in the request. However, adding a check for `Content-Length` header may conflict prior installations.*
2. For requests that rely on a payload, a 'strict' setting **should** mean a valid and a non-empty JSON payload. In other words, an extra `options` value to test for empty/non-empty payloads may not be required.

* - For my purpose, I have a middleware before JSON body parser that looks for multiple headers including `Content-Length` for this requirment.