### PR TITLE
Make it work with Async Hooks

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@ unreleased
     - deps: http-errors@1.7.3
   * deps: safe-buffer@5.2.0
   * deps: type-is@~1.6.18
+  * Make it work with Async Hooks
 
 1.19.0 / 2019-04-25
 ===================

--- a/lib/read.js
+++ b/lib/read.js
@@ -17,6 +17,12 @@ var iconv = require('iconv-lite')
 var onFinished = require('on-finished')
 var zlib = require('zlib')
 
+var asyncHooks
+try {
+  asyncHooks = require('async_hooks')
+} catch (ignored) {
+}
+
 /**
  * Module exports.
  */
@@ -74,7 +80,7 @@ function read (req, res, next, parse, debug, options) {
 
   // read body
   debug('read body')
-  getBody(stream, opts, function (error, body) {
+  getBody(stream, opts, preserveAsyncContext('GetBody', function (error, body) {
     if (error) {
       var _error
 
@@ -91,9 +97,9 @@ function read (req, res, next, parse, debug, options) {
 
       // read off entire request
       stream.resume()
-      onFinished(req, function onfinished () {
+      onFinished(req, preserveAsyncContext('OnFinished', function onfinished () {
         next(createError(400, _error))
-      })
+      }))
       return
     }
 
@@ -128,7 +134,7 @@ function read (req, res, next, parse, debug, options) {
     }
 
     next()
-  })
+  }))
 }
 
 /**
@@ -178,4 +184,15 @@ function contentstream (req, debug, inflate) {
   }
 
   return stream
+}
+
+function preserveAsyncContext (asyncResourceType, fn) {
+  if (!asyncHooks) {
+    return fn
+  }
+  var asyncResource = new asyncHooks.AsyncResource(asyncResourceType)
+  return function () {
+    var args = [].slice.call(arguments)
+    asyncResource.runInAsyncScope.apply(asyncResource, [fn, null].concat(args))
+  }
 }

--- a/lib/read.js
+++ b/lib/read.js
@@ -191,8 +191,5 @@ function preserveAsyncContext (asyncResourceType, fn) {
     return fn
   }
   var asyncResource = new asyncHooks.AsyncResource(asyncResourceType)
-  return function () {
-    var args = [].slice.call(arguments)
-    asyncResource.runInAsyncScope.apply(asyncResource, [fn, null].concat(args))
-  }
+  return asyncResource.runInAsyncScope.bind(asyncResource, fn, null)
 }


### PR DESCRIPTION
This is the reimplementation of #404 using `AsyncResource` instead of promise wrappers, as @Qard advised.
Tests were taken in their entirety from the original PR.