### PR TITLE
Updated Debug library

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "bytes": "3.1.0",
     "content-type": "~1.0.4",
-    "debug": "2.6.9",
+    "debug": "^4.3.2",
     "depd": "~1.1.2",
     "http-errors": "1.7.3",
     "iconv-lite": "0.4.24",


### PR DESCRIPTION
Debug Library < 4.1.1 are detected as vulnerable and may be blockers to many projects having vulnerability scan enabled.

This PR updates Debug Library to the latest version to avoid the library getting detected as vulnerable