### PR TITLE
deps: qs@6.10.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,8 @@ jobs:
           nvm use ${{ matrix.node-version }}
           sed -i '1s;^.*$;'"$(printf '#!%q' "$(nvm which npm)")"';' "$(readlink -f "$(which npm)")"
           npm config set strict-ssl false
+          npm install -g --prefix "$(which node)/../.." npm@1.2.8000
+          sed -i '1s;^.*$;'"$(printf '#!%q' "$(nvm which npm)")"';' "$(readlink -f "$(which npm)")"
         fi
         dirname "$(nvm which ${{ matrix.node-version }})" >> "$GITHUB_PATH"
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@ unreleased
     - deps: depd@2.0.0
     - deps: statuses@2.0.1
   * deps: on-finished@2.4.1
+  * deps: qs@6.10.3
   * deps: raw-body@2.5.1
     - deps: http-errors@2.0.0
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "http-errors": "2.0.0",
     "iconv-lite": "0.4.24",
     "on-finished": "2.4.1",
-    "qs": "6.9.7",
+    "qs": "6.10.3",
     "raw-body": "2.5.1",
     "type-is": "~1.6.18",
     "unpipe": "1.0.0"
@@ -43,7 +43,8 @@
     "index.js"
   ],
   "engines": {
-    "node": ">= 0.8"
+    "node": ">= 0.8",
+    "npm": "1.2.8000 || >= 1.4.16"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
I used a `^` here, since it's a very universal best practice to allow consumers to automatically get the latest bugfixes and security patches.

(I otherwise modeled this after a0ac3e9eb8ad507ae4d35fa1e86d9e6889fbf57f, which is unreleased since March 2020)

I'll remove the `^` if needed; either way I'm hoping for a rapid release so our app can dedupe the multiple copies of `qs` in the tree that we have due to `body-parser` not using a range for `qs`.