### PR TITLE
chore(std bump): Updated debug's version to 4.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "bytes": "3.1.2",
     "content-type": "~1.0.4",
-    "debug": "2.6.9",
+    "debug": "4.3.3",
     "depd": "~1.1.2",
     "http-errors": "1.8.1",
     "iconv-lite": "0.4.24",


### PR DESCRIPTION
There's an issue with debug showing different timestamp formats on different versions. As far as I'm aware it introduces no errors to upgrade.

debug-js/debug#867

@Qix- asked to be mentioned