### PR TITLE
Fix error content-encoding type

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -177,6 +177,11 @@ function contentstream (req, debug, inflate) {
       stream = req
       stream.length = length
       break
+    case 'utf-8': 
+      // fix this issues: https://github.com/expressjs/body-parser/issues/100
+      stream = req
+      stream.length = length
+      break
     default:
       throw createError(415, 'unsupported content encoding "' + encoding + '"', {
         encoding: encoding,


### PR DESCRIPTION
fix this issues: https://github.com/expressjs/body-parser/issues/100