### PR TITLE
Add post-parsing verify function

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -50,6 +50,7 @@ function read (req, res, next, parse, debug, options) {
     ? opts.encoding
     : null
   var verify = opts.verify
+  var verifyParsed = opts.verifyParsed
 
   try {
     // get the content stream
@@ -125,7 +126,11 @@ function read (req, res, next, parse, debug, options) {
       str = typeof body !== 'string' && encoding !== null
         ? iconv.decode(body, encoding)
         : body
-      req.body = parse(str)
+      var parsedBody = parse(str)
+      if (verifyParsed) {
+        verifyParsed(req, res, parsedBody)
+      }
+      req.body = parsedBody
     } catch (err) {
       next(createError(400, err, {
         body: str,

--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -58,9 +58,14 @@ function json (options) {
   var strict = opts.strict !== false
   var type = opts.type || 'application/json'
   var verify = opts.verify || false
+  var verifyParsed = opts.verifyParsed || false
 
   if (verify !== false && typeof verify !== 'function') {
     throw new TypeError('option verify must be function')
+  }
+
+  if (verifyParsed !== false && typeof verifyParsed !== 'function') {
+    throw new TypeError('option verifyParsed must be function')
   }
 
   // create the appropriate type checking function
@@ -136,7 +141,8 @@ function json (options) {
       encoding: charset,
       inflate: inflate,
       limit: limit,
-      verify: verify
+      verify: verify,
+      verifyParsed: verifyParsed
     })
   }
 }


### PR DESCRIPTION
Allow user to specify a function to run on the parsed output.  This function gets the req and res as does the normal parsing middlewares but operates on the parsed data.

This patch is only a sketch to illustrate my idea, I haven't implemented tests or anything, but wanted to see if such a feature is of interest to the project.  I would also add this functionality to the other parsed body types if the patch is acceptable.

My specific use case is that i want to use bodyparser with json-schema. I wanted to use the verify function option, but in order to do that I would need to reparse the json.  I could also wrap the bodyparser middleware in my own middleware, but this is more complicated than adding for example `verifyParsed: (rq,rs,b) => {validate(b)}` to the bodyparser middleware.