### PR TITLE
deps: debug@3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "bytes": "3.1.2",
     "content-type": "~1.0.5",
-    "debug": "2.6.9",
+    "debug": "3.1.0",
     "depd": "2.0.0",
     "destroy": "1.2.0",
     "http-errors": "2.0.0",


### PR DESCRIPTION
Demo library version 2.6.9 has vulnerability issues and we should update it to at least version 3.1.0
Here is the link for more information: https://vulners.com/osv/OSV:GHSA-9VVW-CC9W-F27H
![image](https://user-images.githubusercontent.com/60115295/217828211-78084e47-e954-483b-a680-e09f070c83a3.png)

All tests passed without issues
![image](https://user-images.githubusercontent.com/60115295/217828297-206a0de0-246b-41aa-a120-88858bed537d.png)
