### PR TITLE
Updates `debug` package to address security alert

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "bytes": "3.1.2",
     "content-type": "~1.0.5",
-    "debug": "2.6.9",
+    "debug": "3.2.7",
     "depd": "2.0.0",
     "destroy": "1.2.0",
     "http-errors": "2.0.0",


### PR DESCRIPTION
Addresses the [VDB-217665](https://security.snyk.io/vuln/SNYK-DEBIAN11-NODEDEBUG-3231713) vulnerability on versions matching <3.1.0-1.

Stayed within version 3.x instead of the latest v4. v4 does not install or function on lower versions of Node listed in the work-flow.

Verified that all interfaces used in the body-parser code are still supported. Also verified by running the tests and enabling the debug messages via:

```
DEBUG=* npm run test
```

Verified the tests pass locally on all the LTS versions but depending on the GH Action to run against all node versions supported to verify it continues to work for them.