### PR TITLE
Custom JSON parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,15 +92,15 @@ to `'100kb'`.
 ##### parser
 
 The `parser` option can be used to supply a custom JSON parser used to 
-convert the request body to a Javascript object. If a `reviver` is 
-supplied, it is supplied as the second argument to this function.
+convert the request body to a Javascript object. If the `reviver` option 
+is supplied, it is used as the second argument to this function.
 
 Defaults to `JSON.parse`.
 
 ##### reviver
 
-The `reviver` option is passed directly to `JSON.parse` as the second
-argument. You can find more information on this argument
+The `reviver` option is passed directly to `JSON.parse` (or custom parser) 
+as the second argument. You can find more information on this argument
 [in the MDN documentation about JSON.parse](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Example.3A_Using_the_reviver_parameter).
 
 ##### strict

--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ specifies the number of bytes; if it is a string, the value is passed to the
 [bytes](https://www.npmjs.com/package/bytes) library for parsing. Defaults
 to `'100kb'`.
 
+##### parser
+
+The `parser` option can be used to supply a custom JSON parser used to 
+convert the request body to a Javascript object. If a `reviver` is 
+supplied, it is supplied as the second argument to this function.
+
+Defaults to `JSON.parse`.
+
 ##### reviver
 
 The `reviver` option is passed directly to `JSON.parse` as the second

--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -57,6 +57,7 @@ function json (options) {
     ? bytes.parse(opts.limit || '100kb')
     : opts.limit
   var inflate = opts.inflate !== false
+  var parser = opts.parser || JSON.parse
   var reviver = opts.reviver
   var strict = opts.strict !== false
   var type = opts.type || 'application/json'
@@ -89,12 +90,18 @@ function json (options) {
 
     try {
       debug('parse json')
-      return JSON.parse(body, reviver)
+      return parser(body, reviver)
     } catch (e) {
-      throw normalizeJsonSyntaxError(e, {
-        message: e.message,
-        stack: e.stack
-      })
+      // Only normalize errors if using default parser
+      // Custom parsers might throw custom errors
+      if (parser === JSON.parse) {
+        throw normalizeJsonSyntaxError(e, {
+          message: e.message,
+          stack: e.stack
+        })
+      } else {
+        throw e
+      }
     }
   }
 

--- a/test/json.js
+++ b/test/json.js
@@ -305,6 +305,38 @@ describe('bodyParser.json()', function () {
     })
   })
 
+  describe('with reviver option', function () {
+    it('should use custom reviver', function (done) {
+      request(createServer({
+        reviver: function () {
+          return 'bar'
+        }
+      }))
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .send('{"foo":""}')
+        .expect(200, '"bar"', done)
+    })
+
+  })
+
+  describe('with parser option', function () {
+    it('should use custom parser and pass reviver to it', function (done) {
+      request(createServer({
+        parser: function (body, reviver) {
+          return { foo: reviver() }
+        },
+        reviver: function () {
+          return 'bar'
+        }
+      }))
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .send('{"str":""}')
+        .expect(200, '{"foo":"bar"}', done)
+    })
+  })
+
   describe('with type option', function () {
     describe('when "application/vnd.api+json"', function () {
       before(function () {


### PR DESCRIPTION
To solve the need for custom JSON parses, like in issue [#278] and issue [#478], I've added an option for a custom JSON parser. This is a simpler implementation with more limited scope than the stale [#282] PR.

I was a bit unsure on how to best handle the custom error handling/normalization built into the existing JSON parser. I opted for skipping this when supplied with a custom parser, to allow custom parsers to throw their own errors without manipulation, mostly since the normalizeJsonSyntaxError method removes all keys except message and stack, which might be set on custom and errors and might be useful for those using custom parsers. 

```JS
      // Only normalize errors if using default parser
      // Custom parsers might throw custom errors
      if (parser === JSON.parse) {
        throw normalizeJsonSyntaxError(e, {
          message: e.message,
          stack: e.stack
        })
      } else {
        throw e
      }
```

What do you think @dougwilson? Do you have any other feedback that might help get this merged? Thank you.

PS. My personal motivation to implement this feature is to enable the use of json-bigint for parsing json.
