### PR TITLE
ci: fix errors in ci github action for node 8 and 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,80 +51,80 @@ jobs:
           npm-i: mocha@3.5.3 nyc@10.3.2 supertest@2.0.0
 
         - name: io.js 1.x
-          node-version: "1.8"
+          node-version: "1"
           npm-i: mocha@3.5.3 nyc@10.3.2 supertest@2.0.0
 
         - name: io.js 2.x
-          node-version: "2.5"
+          node-version: "2"
           npm-i: mocha@3.5.3 nyc@10.3.2 supertest@2.0.0
 
         - name: io.js 3.x
-          node-version: "3.3"
+          node-version: "3"
           npm-i: mocha@3.5.3 nyc@10.3.2 supertest@2.0.0
 
         - name: Node.js 4.x
-          node-version: "4.9"
+          node-version: "4"
           npm-i: mocha@5.2.0 nyc@11.9.0 supertest@3.4.2
 
         - name: Node.js 5.x
-          node-version: "5.12"
+          node-version: "5"
           npm-i: mocha@5.2.0 nyc@11.9.0 supertest@3.4.2
 
         - name: Node.js 6.x
-          node-version: "6.17"
+          node-version: "6"
           npm-i: mocha@6.2.2 nyc@14.1.1 supertest@6.1.6
 
         - name: Node.js 7.x
-          node-version: "7.10"
+          node-version: "7"
           npm-i: mocha@6.2.2 nyc@14.1.1 supertest@6.1.6
 
         - name: Node.js 8.x
-          node-version: "8.17"
+          node-version: "8"
           npm-i: mocha@7.2.0 nyc@14.1.1
 
         - name: Node.js 9.x
-          node-version: "9.11"
+          node-version: "9"
           npm-i: mocha@7.2.0 nyc@14.1.1
 
         - name: Node.js 10.x
-          node-version: "10.24"
+          node-version: "10"
           npm-i: mocha@8.4.0
 
         - name: Node.js 11.x
-          node-version: "11.15"
+          node-version: "11"
           npm-i: mocha@8.4.0
 
         - name: Node.js 12.x
-          node-version: "12.22"
+          node-version: "12"
           npm-i: mocha@9.2.2
 
         - name: Node.js 13.x
-          node-version: "13.14"
+          node-version: "13"
           npm-i: mocha@9.2.2
 
         - name: Node.js 14.x
-          node-version: "14.21"
+          node-version: "14"
 
         - name: Node.js 15.x
-          node-version: "15.14"
+          node-version: "15"
 
         - name: Node.js 16.x
-          node-version: "16.19"
+          node-version: "16"
 
         - name: Node.js 17.x
-          node-version: "17.9"
+          node-version: "17"
 
         - name: Node.js 18.x
-          node-version: "18.14"
+          node-version: "18"
 
         - name: Node.js 19.x
-          node-version: "19.7"
+          node-version: "19"
 
         - name: Node.js 20.x
-          node-version: "20.12"
+          node-version: "20"
 
         - name: Node.js 21.x
-          node-version: "21.7"
+          node-version: "21"
 
         - name: Node.js 22.x
           node-version: "22"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
           node-version: "21.7"
 
         - name: Node.js 22.x
-          node-version: "22.0"
+          node-version: "22"
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
         - Node.js 17.x
         - Node.js 18.x
         - Node.js 19.x
+        - Node.js 20.x
+        - Node.js 21.x
+        - Node.js 22.x
 
         include:
         - name: Node.js 0.8
@@ -77,11 +80,11 @@ jobs:
 
         - name: Node.js 8.x
           node-version: "8.17"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.2.0 nyc@14.1.1
 
         - name: Node.js 9.x
           node-version: "9.11"
-          npm-i: mocha@7.2.0
+          npm-i: mocha@7.2.0 nyc@14.1.1
 
         - name: Node.js 10.x
           node-version: "10.24"
@@ -117,8 +120,17 @@ jobs:
         - name: Node.js 19.x
           node-version: "19.7"
 
+        - name: Node.js 20.x
+          node-version: "20.12"
+
+        - name: Node.js 21.x
+          node-version: "21.7"
+
+        - name: Node.js 22.x
+          node-version: "22.0"
+
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install Node.js ${{ matrix.node-version }}
       shell: bash -eo pipefail -l {0}
@@ -209,7 +221,7 @@ jobs:
     needs: test
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Install lcov
       shell: bash

--- a/test/body-parser.js
+++ b/test/body-parser.js
@@ -78,21 +78,20 @@ describe('bodyParser()', function () {
     }
 
     function shouldSkipQuery (versionString) {
-      // Temporarily skipping this test on 21
-      // update this implementation to run on those release lines on supported versions once they exist
-      // upstream tracking https://github.com/nodejs/node/pull/51719
+      // Skipping HTTP QUERY tests on Node 21, it is reported in http.METHODS on 21.7.2 but not supported
+      // update this implementation to run on supported versions of 21 once they exist
+      // upstream tracking https://github.com/nodejs/node/issues/51562
       // express tracking issue: https://github.com/expressjs/express/issues/5615
-      var majorsToSkip = {
-        21: true
-      }
-      return majorsToSkip[getMajorVersion(versionString)]
+      return getMajorVersion(versionString) == 21
     }
 
     methods.slice().sort().forEach(function (method) {
       if (method === 'connect') return
-      if (method === 'query' && shouldSkipQuery(process.versions.node)) return
 
       it('should support ' + method.toUpperCase() + ' requests', function (done) {
+        if (method === 'query' && shouldSkipQuery(process.versions.node)) {
+          this.skip()
+        }
         request(this.server)[method]('/')
           .set('Content-Type', 'application/json')
           .set('Content-Length', '15')

--- a/test/body-parser.js
+++ b/test/body-parser.js
@@ -82,7 +82,7 @@ describe('bodyParser()', function () {
       // update this implementation to run on supported versions of 21 once they exist
       // upstream tracking https://github.com/nodejs/node/issues/51562
       // express tracking issue: https://github.com/expressjs/express/issues/5615
-      return getMajorVersion(versionString) == 21
+      return getMajorVersion(versionString) === '21'
     }
 
     methods.slice().sort().forEach(function (method) {

--- a/test/body-parser.js
+++ b/test/body-parser.js
@@ -73,11 +73,24 @@ describe('bodyParser()', function () {
       })
     })
 
-    methods.slice().sort().forEach(function (method) {
-      if (method === 'connect') {
-        // except CONNECT
-        return
+    function getMajorVersion (versionString) {
+      return versionString.split('.')[0]
+    }
+
+    function shouldSkipQuery (versionString) {
+      // Temporarily skipping this test on 21
+      // update this implementation to run on those release lines on supported versions once they exist
+      // upstream tracking https://github.com/nodejs/node/pull/51719
+      // express tracking issue: https://github.com/expressjs/express/issues/5615
+      var majorsToSkip = {
+        21: true
       }
+      return majorsToSkip[getMajorVersion(versionString)]
+    }
+
+    methods.slice().sort().forEach(function (method) {
+      if (method === 'connect') return
+      if (method === 'query' && shouldSkipQuery(process.versions.node)) return
 
       it('should support ' + method.toUpperCase() + ' requests', function (done) {
         request(this.server)[method]('/')


### PR DESCRIPTION
This PR fixes [nyc](https://github.com/istanbuljs/nyc) version to 14.1.1 when running tests in node 8 or node 9. `nyc 15.x `requires a `yargs` package version that requires node >=10.

I've also added the latest versions of node (20, 21 and 22) to the matrix.

Related to https://github.com/jshttp/http-errors/issues/108