### PR TITLE
feat: require an extended body parser

### DIFF
--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -27,12 +27,6 @@ var typeis = require('type-is')
 module.exports = urlencoded
 
 /**
- * Cache of parser modules.
- */
-
-var parsers = Object.create(null)
-
-/**
  * Create a middleware to parse urlencoded bodies.
  *
  * @param {object} [options]
@@ -48,7 +42,6 @@ function urlencoded (options) {
     deprecate('undefined extended: provide extended option')
   }
 
-  var extended = opts.extended !== false
   var inflate = opts.inflate !== false
   var limit = typeof opts.limit !== 'number'
     ? bytes.parse(opts.limit || '100kb')
@@ -61,8 +54,8 @@ function urlencoded (options) {
   }
 
   // create the appropriate query parser
-  var queryparse = extended
-    ? extendedparser(opts)
+  var queryparse = typeof opts.extended === 'function'
+    ? extendedparser(opts.extended, opts)
     : simpleparser(opts)
 
   // create the appropriate type checking function
@@ -129,11 +122,10 @@ function urlencoded (options) {
  * @param {object} options
  */
 
-function extendedparser (options) {
+function extendedparser (parse, options) {
   var parameterLimit = options.parameterLimit !== undefined
     ? options.parameterLimit
     : 1000
-  var parse = parser('qs')
 
   if (isNaN(parameterLimit) || parameterLimit < 1) {
     throw new TypeError('option parameterLimit must be a positive number')
@@ -153,15 +145,8 @@ function extendedparser (options) {
       })
     }
 
-    var arrayLimit = Math.max(100, paramCount)
-
     debug('parse extended urlencoding')
-    return parse(body, {
-      allowPrototypes: true,
-      arrayLimit: arrayLimit,
-      depth: Infinity,
-      parameterLimit: parameterLimit
-    })
+    return parse(body)
   }
 }
 
@@ -204,35 +189,23 @@ function parameterCount (body, limit) {
   return count
 }
 
+let queryStringModule
+
 /**
- * Get parser for module name dynamically.
+ * Loads the querystring module lazily and caches it
  *
- * @param {string} name
  * @return {function}
  * @api private
  */
 
-function parser (name) {
-  var mod = parsers[name]
-
-  if (mod !== undefined) {
-    return mod.parse
+function loadQueryStringModule () {
+  if (queryStringModule) {
+    return queryStringModule.parse
   }
 
-  // this uses a switch for static require analysis
-  switch (name) {
-    case 'qs':
-      mod = require('qs')
-      break
-    case 'querystring':
-      mod = require('querystring')
-      break
-  }
+  queryStringModule = require('querystring')
 
-  // store to prevent invoking require()
-  parsers[name] = mod
-
-  return mod.parse
+  return queryStringModule.parse
 }
 
 /**
@@ -245,7 +218,7 @@ function simpleparser (options) {
   var parameterLimit = options.parameterLimit !== undefined
     ? options.parameterLimit
     : 1000
-  var parse = parser('querystring')
+  var parse = loadQueryStringModule()
 
   if (isNaN(parameterLimit) || parameterLimit < 1) {
     throw new TypeError('option parameterLimit must be a positive number')

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "http-errors": "2.0.0",
     "iconv-lite": "0.4.24",
     "on-finished": "2.4.1",
-    "qs": "6.12.3",
     "raw-body": "2.5.2",
     "type-is": "~1.6.18",
     "unpipe": "1.0.0"


### PR DESCRIPTION
This changes `extended` to be settable to a custom body parser, or `false`.

When `false`, the simple parser (`node:querystring`) will be used which supports the following syntax:

- `foo=a&foo=b` becomes `{"foo":["a","b"]}`
- `foo=bar` becomes `{"foo":"bar"}`

Otherwise, it must be a function which parses the given string:

```ts
{
  "extended": (bodyStr) => {
    const params = new URLSearchParams(bodyStr);
    return convertURLSearchParamsToObject(params);
  }
}
```

This way the library no longer enforces a specific query string parser, but instead pushes the user to bring their own.

Most users will be fine with `URLSearchParams`, so it may make sense for us to implement a very basic conversion of that to a plain object (like in the example above).

If anyone wants more than that, they can bring their own library and pass it in.

cc @wesleytodd this is what i was trying to explain in my comments elsewhere in the other PR. i don't think `body-parser` should be shipping with a query string parser since it may not always be enabled (so would be a waste). I think we should have a very basic nested parser or none at all

i did this to explain to you what was in my head. if its the totally opposite direction of whats in yours, please feel free to discard the PR. i'll leave it as draft meanwhile