### PR TITLE
Remove redundant depth check

### DIFF
--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -55,9 +55,6 @@ function urlencoded (options) {
     : opts.limit
   var type = opts.type || 'application/x-www-form-urlencoded'
   var verify = opts.verify || false
-  var depth = typeof opts.depth !== 'number'
-    ? Number(opts.depth || 32)
-    : opts.depth
 
   if (verify !== false && typeof verify !== 'function') {
     throw new TypeError('option verify must be function')
@@ -121,8 +118,7 @@ function urlencoded (options) {
       encoding: charset,
       inflate: inflate,
       limit: limit,
-      verify: verify,
-      depth: depth
+      verify: verify
     })
   }
 }
@@ -137,10 +133,7 @@ function extendedparser (options) {
   var parameterLimit = options.parameterLimit !== undefined
     ? options.parameterLimit
     : 1000
-
-  var depth = typeof options.depth !== 'number'
-    ? Number(options.depth || 32)
-    : options.depth
+  var depth = options.depth !== undefined ? options.depth : 32
   var parse = parser('qs')
 
   if (isNaN(parameterLimit) || parameterLimit < 1) {


### PR DESCRIPTION
Removes the redundant check for v1 and aligns behavior with 2.0.0.