### PR TITLE
fix: remove brotli support check

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -26,12 +26,6 @@ var zlib = require('zlib')
 module.exports = read
 
 /**
- * @const
- * whether current node version has brotli support
- */
-var hasBrotliSupport = 'createBrotliDecompress' in zlib
-
-/**
  * Read a request into a buffer and parse.
  *
  * @param {object} req
@@ -181,11 +175,9 @@ function contentstream (req, debug, inflate) {
       stream.length = length
       break
     case 'br':
-      if (hasBrotliSupport) {
-        stream = zlib.createBrotliDecompress()
-        debug('brotli decompress body')
-        req.pipe(stream)
-      }
+      stream = zlib.createBrotliDecompress()
+      debug('brotli decompress body')
+      req.pipe(stream)
       break
   }
 

--- a/test/json.js
+++ b/test/json.js
@@ -12,10 +12,6 @@ var describeAsyncHooks = typeof asyncHooks.AsyncLocalStorage === 'function'
   ? describe
   : describe.skip
 
-var hasBrotliSupport = 'createBrotliDecompress' in require('zlib')
-var brotlit = hasBrotliSupport ? it : it.skip
-var nobrotlit = !hasBrotliSupport ? it : it.skip
-
 describe('bodyParser.json()', function () {
   it('should parse JSON', function (done) {
     request(createServer())
@@ -687,20 +683,12 @@ describe('bodyParser.json()', function () {
       test.expect(200, '{"name":"论"}', done)
     })
 
-    brotlit('should support brotli encoding', function (done) {
+    it('should support brotli encoding', function (done) {
       var test = request(this.server).post('/')
       test.set('Content-Encoding', 'br')
       test.set('Content-Type', 'application/json')
       test.write(Buffer.from('8b06807b226e616d65223a22e8aeba227d03', 'hex'))
       test.expect(200, '{"name":"论"}', done)
-    })
-
-    nobrotlit('should throw 415 if there\'s no brotli support', function (done) {
-      var test = request(this.server).post('/')
-      test.set('Content-Encoding', 'br')
-      test.set('Content-Type', 'application/json')
-      test.write(Buffer.from('8b06807b226e616d65223a22e8aeba227d03', 'hex'))
-      test.expect(415, 'unsupported content encoding "br"', done)
     })
 
     it('should be case-insensitive', function (done) {

--- a/test/raw.js
+++ b/test/raw.js
@@ -12,10 +12,6 @@ var describeAsyncHooks = typeof asyncHooks.AsyncLocalStorage === 'function'
   ? describe
   : describe.skip
 
-var hasBrotliSupport = 'createBrotliDecompress' in require('zlib')
-var brotlit = hasBrotliSupport ? it : it.skip
-var nobrotlit = !hasBrotliSupport ? it : it.skip
-
 describe('bodyParser.raw()', function () {
   before(function () {
     this.server = createServer()
@@ -459,20 +455,12 @@ describe('bodyParser.raw()', function () {
       test.expect(200, 'buf:6e616d653de8aeba', done)
     })
 
-    brotlit('should support brotli encoding', function (done) {
+    it('should support brotli encoding', function (done) {
       var test = request(this.server).post('/')
       test.set('Content-Encoding', 'br')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('8b03806e616d653de8aeba03', 'hex'))
       test.expect(200, 'buf:6e616d653de8aeba', done)
-    })
-
-    nobrotlit('should throw 415 if there\'s no brotli support', function (done) {
-      var test = request(this.server).post('/')
-      test.set('Content-Encoding', 'br')
-      test.set('Content-Type', 'application/octet-stream')
-      test.write(Buffer.from('8b03806e616d653de8aeba03', 'hex'))
-      test.expect(415, 'unsupported content encoding "br"', done)
     })
 
     it('should be case-insensitive', function (done) {

--- a/test/text.js
+++ b/test/text.js
@@ -12,10 +12,6 @@ var describeAsyncHooks = typeof asyncHooks.AsyncLocalStorage === 'function'
   ? describe
   : describe.skip
 
-var hasBrotliSupport = 'createBrotliDecompress' in require('zlib')
-var brotlit = hasBrotliSupport ? it : it.skip
-var nobrotlit = !hasBrotliSupport ? it : it.skip
-
 describe('bodyParser.text()', function () {
   before(function () {
     this.server = createServer()
@@ -529,20 +525,12 @@ describe('bodyParser.text()', function () {
       test.expect(200, '"name is 论"', done)
     })
 
-    brotlit('should support brotli encoding', function (done) {
+    it('should support brotli encoding', function (done) {
       var test = request(this.server).post('/')
       test.set('Content-Encoding', 'br')
       test.set('Content-Type', 'text/plain')
       test.write(Buffer.from('0b05806e616d6520697320e8aeba03', 'hex'))
       test.expect(200, '"name is 论"', done)
-    })
-
-    nobrotlit('should throw 415 if there\'s no brotli support', function (done) {
-      var test = request(this.server).post('/')
-      test.set('Content-Encoding', 'br')
-      test.set('Content-Type', 'text/plain')
-      test.write(Buffer.from('0b05806e616d6520697320e8aeba03', 'hex'))
-      test.expect(415, 'unsupported content encoding "br"', done)
     })
 
     it('should be case-insensitive', function (done) {

--- a/test/urlencoded.js
+++ b/test/urlencoded.js
@@ -12,10 +12,6 @@ var describeAsyncHooks = typeof asyncHooks.AsyncLocalStorage === 'function'
   ? describe
   : describe.skip
 
-var hasBrotliSupport = 'createBrotliDecompress' in require('zlib')
-var brotlit = hasBrotliSupport ? it : it.skip
-var nobrotlit = !hasBrotliSupport ? it : it.skip
-
 describe('bodyParser.urlencoded()', function () {
   before(function () {
     this.server = createServer()
@@ -907,20 +903,12 @@ describe('bodyParser.urlencoded()', function () {
       test.expect(200, '{"name":"论"}', done)
     })
 
-    brotlit('should support brotli encoding', function (done) {
+    it('should support brotli encoding', function (done) {
       var test = request(this.server).post('/')
       test.set('Content-Encoding', 'br')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
       test.write(Buffer.from('8b03806e616d653de8aeba03', 'hex'))
       test.expect(200, '{"name":"论"}', done)
-    })
-
-    nobrotlit('should throw 415 if there\'s no brotli support', function (done) {
-      var test = request(this.server).post('/')
-      test.set('Content-Encoding', 'br')
-      test.set('Content-Type', 'application/x-www-form-urlencoded')
-      test.write(Buffer.from('789ccb4bcc4db57db16e17001068042f', 'hex'))
-      test.expect(415, 'unsupported content encoding "br"', done)
     })
 
     it('should be case-insensitive', function (done) {


### PR DESCRIPTION
with the minimum supported node version set to v18 we can remove the brotli support check as it was added in v11.7.0 and v10.16.0

https://nodejs.org/docs/latest/api/zlib.html#zlibcreatebrotlidecompressoptions