### PR TITLE
fix: remove unpipe package and use native unpipe method

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+unreleased
+=========================
+
+* remove `unpipe` package and use native `unpipe()` method
+
 2.0.1 / 2024-09-10
 =========================
 

--- a/lib/read.js
+++ b/lib/read.js
@@ -16,7 +16,6 @@ var destroy = require('destroy')
 var getBody = require('raw-body')
 var iconv = require('iconv-lite')
 var onFinished = require('on-finished')
-var unpipe = require('unpipe')
 var zlib = require('zlib')
 
 /**
@@ -96,7 +95,7 @@ function read (req, res, next, parse, debug, options) {
 
       // unpipe from stream and destroy
       if (stream !== req) {
-        unpipe(req)
+        req.unpipe()
         destroy(stream, true)
       }
 

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "on-finished": "2.4.1",
     "qs": "6.13.0",
     "raw-body": "^3.0.0",
-    "type-is": "~1.6.18",
-    "unpipe": "1.0.0"
+    "type-is": "~1.6.18"
   },
   "devDependencies": {
     "eslint": "8.34.0",


### PR DESCRIPTION
The [`unpipe`](https://www.npmjs.com/package/unpipe) package was used to unpipes all destinations from a given stream.

Taken from the unpipe readme:

> With stream 2+, this is equivalent to stream.unpipe(). When used with streams 1 style streams (typically Node.js 0.8 and below), this module attempts to undo the actions done in stream.pipe(dest).

As our minimum supported Node version is v18 the `unpipe` package is no longer needed.