### PR TITLE
Remove devDependency `safe-buffer`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "methods": "1.1.2",
     "mocha": "10.2.0",
     "nyc": "15.1.0",
-    "safe-buffer": "5.2.1",
     "supertest": "6.3.3"
   },
   "files": [

--- a/test/json.js
+++ b/test/json.js
@@ -2,7 +2,6 @@
 
 var assert = require('assert')
 var asyncHooks = tryRequire('async_hooks')
-var Buffer = require('safe-buffer').Buffer
 var http = require('http')
 var request = require('supertest')
 

--- a/test/raw.js
+++ b/test/raw.js
@@ -2,7 +2,6 @@
 
 var assert = require('assert')
 var asyncHooks = tryRequire('async_hooks')
-var Buffer = require('safe-buffer').Buffer
 var http = require('http')
 var request = require('supertest')
 

--- a/test/text.js
+++ b/test/text.js
@@ -2,7 +2,6 @@
 
 var assert = require('assert')
 var asyncHooks = tryRequire('async_hooks')
-var Buffer = require('safe-buffer').Buffer
 var http = require('http')
 var request = require('supertest')
 

--- a/test/urlencoded.js
+++ b/test/urlencoded.js
@@ -2,7 +2,6 @@
 
 var assert = require('assert')
 var asyncHooks = tryRequire('async_hooks')
-var Buffer = require('safe-buffer').Buffer
 var http = require('http')
 var request = require('supertest')
 


### PR DESCRIPTION
This PR removes the `safe-buffer` package from devDependencies as it's no longer needed. Since we no longer support Node.js versions older than 18.0.0, the native Buffer class now fully handles security concerns. Additionally, there are no instances of `new Buffer(...)` usage in the repository.