### PR TITLE
Remove unused devDependency `methods`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-promise": "6.1.1",
     "eslint-plugin-standard": "4.1.0",
-    "methods": "1.1.2",
     "mocha": "10.2.0",
     "nyc": "15.1.0",
     "safe-buffer": "5.2.1",


### PR DESCRIPTION
This PR removes the unused `methods` package from `devDependencies`. After reviewing the codebase, i think that `methods` is no longer required or used anywhere in the project.