### PR TITLE
test: remove AsyncLocalStorage check

### DIFF
--- a/test/json.js
+++ b/test/json.js
@@ -1,15 +1,11 @@
 'use strict'
 
 var assert = require('assert')
-var asyncHooks = tryRequire('async_hooks')
+var AsyncLocalStorage = require('async_hooks').AsyncLocalStorage
 var http = require('http')
 var request = require('supertest')
 
 var bodyParser = require('..')
-
-var describeAsyncHooks = typeof asyncHooks.AsyncLocalStorage === 'function'
-  ? describe
-  : describe.skip
 
 describe('bodyParser.json()', function () {
   it('should parse JSON', function (done) {
@@ -511,13 +507,13 @@ describe('bodyParser.json()', function () {
     })
   })
 
-  describeAsyncHooks('async local storage', function () {
+  describe('async local storage', function () {
     before(function () {
       var jsonParser = bodyParser.json()
       var store = { foo: 'bar' }
 
       this.server = createServer(function (req, res, next) {
-        var asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
+        var asyncLocalStorage = new AsyncLocalStorage()
 
         asyncLocalStorage.run(store, function () {
           jsonParser(req, res, function (err) {
@@ -759,13 +755,5 @@ function shouldContainInBody (str) {
   return function (res) {
     assert.ok(res.text.indexOf(str) !== -1,
       'expected \'' + res.text + '\' to contain \'' + str + '\'')
-  }
-}
-
-function tryRequire (name) {
-  try {
-    return require(name)
-  } catch (e) {
-    return {}
   }
 }

--- a/test/raw.js
+++ b/test/raw.js
@@ -1,15 +1,11 @@
 'use strict'
 
 var assert = require('assert')
-var asyncHooks = tryRequire('async_hooks')
+var AsyncLocalStorage = require('async_hooks').AsyncLocalStorage
 var http = require('http')
 var request = require('supertest')
 
 var bodyParser = require('..')
-
-var describeAsyncHooks = typeof asyncHooks.AsyncLocalStorage === 'function'
-  ? describe
-  : describe.skip
 
 describe('bodyParser.raw()', function () {
   before(function () {
@@ -329,13 +325,13 @@ describe('bodyParser.raw()', function () {
     })
   })
 
-  describeAsyncHooks('async local storage', function () {
+  describe('async local storage', function () {
     before(function () {
       var rawParser = bodyParser.raw()
       var store = { foo: 'bar' }
 
       this.server = createServer(function (req, res, next) {
-        var asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
+        var asyncLocalStorage = new AsyncLocalStorage()
 
         asyncLocalStorage.run(store, function () {
           rawParser(req, res, function (err) {
@@ -501,12 +497,4 @@ function createServer (opts) {
       res.end(JSON.stringify(req.body) || typeof req.body)
     })
   })
-}
-
-function tryRequire (name) {
-  try {
-    return require(name)
-  } catch (e) {
-    return {}
-  }
 }

--- a/test/text.js
+++ b/test/text.js
@@ -1,15 +1,11 @@
 'use strict'
 
 var assert = require('assert')
-var asyncHooks = tryRequire('async_hooks')
+var AsyncLocalStorage = require('async_hooks').AsyncLocalStorage
 var http = require('http')
 var request = require('supertest')
 
 var bodyParser = require('..')
-
-var describeAsyncHooks = typeof asyncHooks.AsyncLocalStorage === 'function'
-  ? describe
-  : describe.skip
 
 describe('bodyParser.text()', function () {
   before(function () {
@@ -370,13 +366,13 @@ describe('bodyParser.text()', function () {
     })
   })
 
-  describeAsyncHooks('async local storage', function () {
+  describe('async local storage', function () {
     before(function () {
       var textParser = bodyParser.text()
       var store = { foo: 'bar' }
 
       this.server = createServer(function (req, res, next) {
-        var asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
+        var asyncLocalStorage = new AsyncLocalStorage()
 
         asyncLocalStorage.run(store, function () {
           textParser(req, res, function (err) {
@@ -564,12 +560,4 @@ function createServer (opts) {
       )
     })
   })
-}
-
-function tryRequire (name) {
-  try {
-    return require(name)
-  } catch (e) {
-    return {}
-  }
 }

--- a/test/urlencoded.js
+++ b/test/urlencoded.js
@@ -1,15 +1,11 @@
 'use strict'
 
 var assert = require('assert')
-var asyncHooks = tryRequire('async_hooks')
+var AsyncLocalStorage = require('async_hooks').AsyncLocalStorage
 var http = require('http')
 var request = require('supertest')
 
 var bodyParser = require('..')
-
-var describeAsyncHooks = typeof asyncHooks.AsyncLocalStorage === 'function'
-  ? describe
-  : describe.skip
 
 describe('bodyParser.urlencoded()', function () {
   before(function () {
@@ -755,13 +751,13 @@ describe('bodyParser.urlencoded()', function () {
     })
   })
 
-  describeAsyncHooks('async local storage', function () {
+  describe('async local storage', function () {
     before(function () {
       var urlencodedParser = bodyParser.urlencoded()
       var store = { foo: 'bar' }
 
       this.server = createServer(function (req, res, next) {
-        var asyncLocalStorage = new asyncHooks.AsyncLocalStorage()
+        var asyncLocalStorage = new AsyncLocalStorage()
 
         asyncLocalStorage.run(store, function () {
           urlencodedParser(req, res, function (err) {
@@ -966,13 +962,5 @@ function createServer (opts) {
 function expectKeyCount (count) {
   return function (res) {
     assert.strictEqual(Object.keys(JSON.parse(res.text)).length, count)
-  }
-}
-
-function tryRequire (name) {
-  try {
-    return require(name)
-  } catch (e) {
-    return {}
   }
 }


### PR DESCRIPTION
with the minimum supported node version set to v18 we can remove the AsyncLocalStorage support check as it was added in v13.10.0 and v12.17.0