### PR TITLE
Refactor contentstream function to modern syntax and improve readability

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -141,23 +141,24 @@ function read (req, res, next, parse, debug, options) {
  * @param {function} debug
  * @param {boolean} [inflate=true]
  * @return {object}
+ * @throws {Error}
  * @api private
  */
 
 function contentstream (req, debug, inflate) {
-  var encoding = (req.headers['content-encoding'] || 'identity').toLowerCase()
-  var length = req.headers['content-length']
-  var stream
+  const encoding = (req.headers['content-encoding'] || 'identity').toLowerCase()
+  const length = req.headers['content-length']
 
-  debug('content-encoding "%s"', encoding)
+  debug(`content-encoding "${encoding}"`)
 
-  if (inflate === false && encoding !== 'identity') {
+  if (!inflate && encoding !== 'identity') {
     throw createError(415, 'content encoding unsupported', {
-      encoding: encoding,
+      encoding,
       type: 'encoding.unsupported'
     })
   }
 
+  let stream
   switch (encoding) {
     case 'deflate':
       stream = zlib.createInflate()
@@ -169,22 +170,20 @@ function contentstream (req, debug, inflate) {
       debug('gunzip body')
       req.pipe(stream)
       break
-    case 'identity':
-      stream = req
-      stream.length = length
-      break
     case 'br':
       stream = zlib.createBrotliDecompress()
       debug('brotli decompress body')
       req.pipe(stream)
       break
-  }
-
-  if (stream === undefined) {
-    throw createError(415, 'unsupported content encoding "' + encoding + '"', {
-      encoding: encoding,
-      type: 'encoding.unsupported'
-    })
+    case 'identity':
+      stream = req
+      stream.length = length
+      break
+    default:
+      throw createError(415, `unsupported content encoding "${encoding}"`, {
+        encoding,
+        type: 'encoding.unsupported'
+      })
   }
 
   return stream


### PR DESCRIPTION
- Replaced `var` with `const` and `let` for better variable management
- Simplified error handling by throwing directly within the switch statement
- Updated debug messages for more consistent output
- Switched to a more concise structure for defining the `stream` variable