### PR TITLE
perf: use the node require cache instead of custom caching

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,13 +7,6 @@
 'use strict'
 
 /**
- * Cache of loaded parsers.
- * @private
- */
-
-var parsers = Object.create(null)
-
-/**
  * @typedef Parsers
  * @type {function}
  * @property {function} json
@@ -37,7 +30,7 @@ exports = module.exports = bodyParser
 Object.defineProperty(exports, 'json', {
   configurable: true,
   enumerable: true,
-  get: createParserGetter('json')
+  get: () => require('./lib/types/json')
 })
 
 /**
@@ -48,7 +41,7 @@ Object.defineProperty(exports, 'json', {
 Object.defineProperty(exports, 'raw', {
   configurable: true,
   enumerable: true,
-  get: createParserGetter('raw')
+  get: () => require('./lib/types/raw')
 })
 
 /**
@@ -59,7 +52,7 @@ Object.defineProperty(exports, 'raw', {
 Object.defineProperty(exports, 'text', {
   configurable: true,
   enumerable: true,
-  get: createParserGetter('text')
+  get: () => require('./lib/types/text')
 })
 
 /**
@@ -70,7 +63,7 @@ Object.defineProperty(exports, 'text', {
 Object.defineProperty(exports, 'urlencoded', {
   configurable: true,
   enumerable: true,
-  get: createParserGetter('urlencoded')
+  get: () => require('./lib/types/urlencoded')
 })
 
 /**
@@ -84,47 +77,4 @@ Object.defineProperty(exports, 'urlencoded', {
 
 function bodyParser () {
   throw new Error('The bodyParser() generic has been split into individual middleware to use instead.')
-}
-
-/**
- * Create a getter for loading a parser.
- * @private
- */
-
-function createParserGetter (name) {
-  return function get () {
-    return loadParser(name)
-  }
-}
-
-/**
- * Load a parser module.
- * @private
- */
-
-function loadParser (parserName) {
-  var parser = parsers[parserName]
-
-  if (parser !== undefined) {
-    return parser
-  }
-
-  // this uses a switch for static require analysis
-  switch (parserName) {
-    case 'json':
-      parser = require('./lib/types/json')
-      break
-    case 'raw':
-      parser = require('./lib/types/raw')
-      break
-    case 'text':
-      parser = require('./lib/types/text')
-      break
-    case 'urlencoded':
-      parser = require('./lib/types/urlencoded')
-      break
-  }
-
-  // store to prevent invoking require()
-  return (parsers[parserName] = parser)
 }


### PR DESCRIPTION
This PR replaces the custom caching logic with [Node.js's built-in require cache](https://nodejs.org/api/modules.html#caching). By leveraging the require cache, the codebase is simplified, performance is improved, and maintenance overhead is reduced. The custom logic has been removed, and the parser loading now relies on `require`.