### PR TITLE
ci: disable fail-fast in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
     name: Test - Node.js ${{ matrix.node-version }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         node-version: [18, 19, 20, 21, 22, 23]
 


### PR DESCRIPTION
Added `fail-fast: false` to the job strategy matrix to ensure that the tests run on all node versions even if one of them fails.