### PR TITLE
cleanup: remove obsolete test env file

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "scripts": {
     "lint": "eslint .",
-    "test": "mocha --require test/support/env --reporter spec --check-leaks --bail test/",
+    "test": "mocha --reporter spec --check-leaks --bail test/",
     "test-ci": "nyc --reporter=lcov --reporter=text npm test",
     "test-cov": "nyc --reporter=html --reporter=text npm test"
   }

--- a/test/support/env.js
+++ b/test/support/env.js
@@ -1,2 +1,0 @@
-
-process.env.NO_DEPRECATION = 'body-parser'


### PR DESCRIPTION
The `test/support/env.js` file contained the definition of an environment variable which was only used to silence [`depd`](https://www.npmjs.com/package/depd) during tests. Since `depd` is not used anymore, we can safely remove the file.

The `NO_DEPRECATION` environment variable is documented here: https://github.com/dougwilson/nodejs-depd?tab=readme-ov-file#processenvno_deprecation

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->