### PR TITLE
fix: remove obsolete dependency `destroy`

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -12,7 +12,6 @@
  */
 
 var createError = require('http-errors')
-var destroy = require('destroy')
 var getBody = require('raw-body')
 var iconv = require('iconv-lite')
 var onFinished = require('on-finished')
@@ -90,7 +89,7 @@ function read (req, res, next, parse, debug, options) {
       // unpipe from stream and destroy
       if (stream !== req) {
         req.unpipe()
-        destroy(stream, true)
+        stream.destroy()
       }
 
       // read off entire request

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "bytes": "3.1.2",
     "content-type": "~1.0.5",
     "debug": "3.1.0",
-    "destroy": "1.2.0",
     "http-errors": "2.0.0",
     "iconv-lite": "0.5.2",
     "on-finished": "2.4.1",


### PR DESCRIPTION
The [`destroy`](https://www.npmjs.com/package/destroy) package was was used to handle stream destruction across legacy Node.js versions (>=0.8), addressing bugs in specific versions. Since we now officially support only Node.js 18 and newer, we can safely remove this dependency and replace it with a direct call to `stream.destroy()`.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->