### PR TITLE
refactor: prefix built-in node module imports

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@ unreleased
 =========================
 
 * deps: type-is@^2.0.0
+* refactor: prefix built-in node module imports
 
 2.0.2 / 2024-10-31
 =========================

--- a/lib/read.js
+++ b/lib/read.js
@@ -16,7 +16,7 @@ var destroy = require('destroy')
 var getBody = require('raw-body')
 var iconv = require('iconv-lite')
 var onFinished = require('on-finished')
-var zlib = require('zlib')
+var zlib = require('node:zlib')
 
 /**
  * Module exports.

--- a/test/body-parser.js
+++ b/test/body-parser.js
@@ -1,6 +1,6 @@
 'use strict'
 
-var assert = require('assert')
+var assert = require('node:assert')
 
 var bodyParser = require('..')
 

--- a/test/json.js
+++ b/test/json.js
@@ -1,8 +1,8 @@
 'use strict'
 
-var assert = require('assert')
-var AsyncLocalStorage = require('async_hooks').AsyncLocalStorage
-var http = require('http')
+var assert = require('node:assert')
+var AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
+var http = require('node:http')
 var request = require('supertest')
 
 var bodyParser = require('..')

--- a/test/raw.js
+++ b/test/raw.js
@@ -1,8 +1,8 @@
 'use strict'
 
-var assert = require('assert')
-var AsyncLocalStorage = require('async_hooks').AsyncLocalStorage
-var http = require('http')
+var assert = require('node:assert')
+var AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
+var http = require('node:http')
 var request = require('supertest')
 
 var bodyParser = require('..')

--- a/test/text.js
+++ b/test/text.js
@@ -1,8 +1,8 @@
 'use strict'
 
-var assert = require('assert')
-var AsyncLocalStorage = require('async_hooks').AsyncLocalStorage
-var http = require('http')
+var assert = require('node:assert')
+var AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
+var http = require('node:http')
 var request = require('supertest')
 
 var bodyParser = require('..')

--- a/test/urlencoded.js
+++ b/test/urlencoded.js
@@ -1,8 +1,8 @@
 'use strict'
 
-var assert = require('assert')
-var AsyncLocalStorage = require('async_hooks').AsyncLocalStorage
-var http = require('http')
+var assert = require('node:assert')
+var AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
+var http = require('node:http')
 var request = require('supertest')
 
 var bodyParser = require('..')


### PR DESCRIPTION
Align with changes introduced in expressjs/express#6236 by prefixing all built-in Node.js module imports with 'node:'.

Reference: https://github.com/expressjs/express/pull/6236

Taken from that PR: 

> Since v5 relies on node >= 18, this is now possible (since v16, v14.18.0 [1](#user-content-fn-1-187b236bd1bd1a27071fe304ad924f75) [2](#user-content-fn-2-187b236bd1bd1a27071fe304ad924f75)).
> 
> It's functionally irrelevant:
> 
> 1. It's not required for CJS nor ESM (with a few exceptions [3](#user-content-fn-3-187b236bd1bd1a27071fe304ad924f75))
> 2. It has no performance promises
> 
> However, there are upsides to this approach:
> 
> 1. It brings clear boundaries to what's a built-in and what's an external dependency
> 2. It reduces the risk of importing unwanted deps where a built-in is expected
> 3. It's slightly more interoperable with other JS runtimes that provide node compatibility[4](#user-content-fn-4-187b236bd1bd1a27071fe304ad924f75), albeit only during development. Once imported from npm, built-ins are assumed.
> 
> ## Footnotes
> 1. https://nodejs.org/docs/latest-v22.x/api/modules.html#built-in-modules [↩](#user-content-fnref-1-187b236bd1bd1a27071fe304ad924f75)
> 2. https://github.com/nodejs/node/pull/37246 [↩](#user-content-fnref-2-187b236bd1bd1a27071fe304ad924f75)
> 3. https://nodejs.org/api/modules.html#built-in-modules-with-mandatory-node-prefix [↩](#user-content-fnref-3-187b236bd1bd1a27071fe304ad924f75)
> 4. https://docs.deno.com/runtime/fundamentals/node/#using-node's-built-in-modules [↩](#user-content-fnref-4-187b236bd1bd1a27071fe304ad924f75)



<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->