### PR TITLE
chore(deps): update `debug` to ^4.4.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -3,6 +3,7 @@ unreleased
 
 * deps:
   * type-is@^2.0.0
+  * debug@^4.4.0
   * Removed destroy
 * refactor: prefix built-in node module imports
 * use the node require cache instead of custom caching

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "bytes": "^3.1.2",
     "content-type": "^1.0.5",
-    "debug": "^3.1.0",
+    "debug": "^4.4.0",
     "http-errors": "^2.0.0",
     "iconv-lite": "^0.5.2",
     "on-finished": "^2.4.1",


### PR DESCRIPTION
This PR addresses the issue of multiple versions of the `debug` package being installed when using Express v5, which currently results in **four different versions** of `debug`. By updating the `debug` dependency within `body-parser`, we can eliminate one of these redundant versions.

[Dependency Graph for Express v5](https://npmgraph.js.org/?q=express%405)

Related to: 
* https://github.com/expressjs/express/pull/6313
* https://github.com/pillarjs/finalhandler/pull/78
