### PR TITLE
ci: separate lint step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,23 @@ permissions:
   contents: read
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install Node.js dependencies
+        run: npm install --ignore-scripts --include=dev
+
+      - name: Lint code
+        run: npm run lint
+
   test:
     name: Test - Node.js ${{ matrix.node-version }}
     runs-on: ubuntu-latest
@@ -33,9 +50,6 @@ jobs:
 
       - name: Run tests
         run: npm run test-ci
-
-      - name: Lint code
-        run: npm run lint
 
       - name: Upload code coverage
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The same has been done for the main express repo: [`expressjs/express/.github/workflows/ci.yml`](https://github.com/expressjs/express/blob/master/.github/workflows/ci.yml)

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->