### PR TITLE
ci: use `lcovonly` reporter for the `test-ci` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "scripts": {
     "lint": "eslint .",
     "test": "mocha --reporter spec --check-leaks --bail test/",
-    "test-ci": "nyc --reporter=lcov --reporter=text npm test",
+    "test-ci": "nyc --reporter=lcovonly --reporter=text npm test",
     "test-cov": "nyc --reporter=html --reporter=text npm test"
   }
 }


### PR DESCRIPTION
The `lcov` reporter generates the `lcov.info` file and a html report. We can skip creating the html report and use the `lcovonly` reporter.