### PR TITLE
Refactor parameterCount to optimize performance

### DIFF
--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -210,7 +210,7 @@ function getCharset (req) {
 function parameterCount (body, limit) {
   var len = body.split('&').length
 
-  return len > limit ? undefined : len - 1;
+  return len > limit ? undefined : len - 1
 }
 
 /**

--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -208,19 +208,9 @@ function getCharset (req) {
  */
 
 function parameterCount (body, limit) {
-  var count = 0
-  var index = 0
+  var len = body.split('&').length;
 
-  while ((index = body.indexOf('&', index)) !== -1) {
-    count++
-    index++
-
-    if (count === limit) {
-      return undefined
-    }
-  }
-
-  return count
+  return len > limit ? undefined : len - 1;
 }
 
 /**

--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -208,7 +208,7 @@ function getCharset (req) {
  */
 
 function parameterCount (body, limit) {
-  var len = body.split('&').length;
+  var len = body.split('&').length
 
   return len > limit ? undefined : len - 1;
 }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "lint": "eslint .",
     "test": "mocha --reporter spec --check-leaks test/",
     "test-ci": "nyc --reporter=lcovonly --reporter=text npm test",
-
     "test-cov": "nyc --reporter=html --reporter=text npm test"
   }
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

Now that body-parser targets Node.js 18, we can finally use String.split to count all the `&`s in `parameterCount` body. This makes the function roughly 2x faster in Chrome/Node.js engine (and about 2.5x faster in Safari/Bun engine), according to this jsperf: https://jsperf.app/niqepi/2

Fun fact: if you run this jsperf in Firefox, the old implementation will get speeds unmatched by any other engine, while the _new_ one will be roughly 7x slower. Thankfully, that's only the case in Firefox.

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

a