### PR TITLE
replace `on-finished` with native `stream.finished` for request handling

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -14,8 +14,8 @@
 var createError = require('http-errors')
 var getBody = require('raw-body')
 var iconv = require('iconv-lite')
-var onFinished = require('on-finished')
 var zlib = require('node:zlib')
+const { finished } = require('node:stream')
 
 /**
  * Module exports.
@@ -204,7 +204,7 @@ function dump (req, callback) {
   if (onFinished.isFinished(req)) {
     callback(null)
   } else {
-    onFinished(req, callback)
+    finished(req, callback)
     req.resume()
   }
 }


### PR DESCRIPTION
I'm investigating how to stop using `on-finished` here and handle it directly with the properties that Node.js provides. I don't know if it's possible or if there are any bugs.  

It's likely that changes will need to be made in raw-body, as it handles a large part of this module's logic.