### PR TITLE
refactor: move req.body = undefined to just before read attempt

### DIFF
--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -90,10 +90,6 @@ function json (options) {
       return
     }
 
-    if (!('body' in req)) {
-      req.body = undefined
-    }
-
     // skip requests without bodies
     if (!typeis.hasBody(req)) {
       debug('skip empty body')
@@ -119,6 +115,10 @@ function json (options) {
         type: 'charset.unsupported'
       }))
       return
+    }
+
+    if (!('body' in req)) {
+      req.body = undefined
     }
 
     // read

--- a/lib/types/raw.js
+++ b/lib/types/raw.js
@@ -44,10 +44,6 @@ function raw (options) {
       return
     }
 
-    if (!('body' in req)) {
-      req.body = undefined
-    }
-
     // skip requests without bodies
     if (!typeis.hasBody(req)) {
       debug('skip empty body')
@@ -62,6 +58,10 @@ function raw (options) {
       debug('skip parsing')
       next()
       return
+    }
+
+    if (!('body' in req)) {
+      req.body = undefined
     }
 
     // read

--- a/lib/types/text.js
+++ b/lib/types/text.js
@@ -46,10 +46,6 @@ function text (options) {
       return
     }
 
-    if (!('body' in req)) {
-      req.body = undefined
-    }
-
     // skip requests without bodies
     if (!typeis.hasBody(req)) {
       debug('skip empty body')
@@ -68,6 +64,10 @@ function text (options) {
 
     // get charset
     var charset = getCharset(req) || defaultCharset
+
+    if (!('body' in req)) {
+      req.body = undefined
+    }
 
     // read
     read(req, res, next, parse, debug, {

--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -58,10 +58,6 @@ function urlencoded (options) {
       return
     }
 
-    if (!('body' in req)) {
-      req.body = undefined
-    }
-
     // skip requests without bodies
     if (!typeis.hasBody(req)) {
       debug('skip empty body')
@@ -87,6 +83,10 @@ function urlencoded (options) {
         type: 'charset.unsupported'
       }))
       return
+    }
+
+    if (!('body' in req)) {
+      req.body = undefined
     }
 
     // read


### PR DESCRIPTION
Reasoning: the various parsers should not modify the request object until it is clear it should be applied. Setting a property, even to undefined, may affect assumptions elsewhere. For example, `'req' in body` would be truthy even if the rest of the middleware was not applied.

Arguably, it can be removed entirely since all tests are still passing without it. But keeping it around in case there are other historical reasons behind it.

In either case, the current version is not compatible with, for example, tRPC v11 when using FormData. So without this change, the workaround is to add a condition to avoid applying the middleware at all. Example:

```js
const json = express.json();
app.use((req, res, next) => {
  if (req.url.includes('trpc')) return next();
  return json(req, res, next);
});
```
