### PR TITLE
feat: add secure JSON parsing with prototype poisoning handling

### DIFF
--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -18,6 +18,7 @@ var isFinished = require('on-finished').isFinished
 var read = require('../read')
 var typeis = require('type-is')
 var { getCharset, normalizeOptions } = require('../utils')
+const secureJson = require('secure-json-parse')
 
 /**
  * Module exports.
@@ -55,6 +56,7 @@ function json (options) {
 
   var reviver = options?.reviver
   var strict = options?.strict !== false
+  const protoPoisoning = options?.onProtoPoisoning || 'ignore'
 
   function parse (body) {
     if (body.length === 0) {
@@ -74,7 +76,7 @@ function json (options) {
 
     try {
       debug('parse json')
-      return JSON.parse(body, reviver)
+      return secureJson.parse(body, reviver, { protoAction: protoPoisoning })
     } catch (e) {
       throw normalizeJsonSyntaxError(e, {
         message: e.message,

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "on-finished": "^2.4.1",
     "qs": "^6.14.0",
     "raw-body": "^3.0.0",
+    "secure-json-parse": "^4.0.0",
     "type-is": "^2.0.0"
   },
   "devDependencies": {

--- a/test/json.js
+++ b/test/json.js
@@ -721,6 +721,32 @@ describe('bodyParser.json()', function () {
       test.expect(413, done)
     })
   })
+
+  describe("prototype poisoning", function () {
+    it('should parse __proto__ when protoAction is set to ignore', function (done) {
+      request(createServer({ onProtoPoisoning: 'ignore' }))
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .send('{"user":"tobi","__proto__":{"x":7}}')
+        .expect(200, '{"user":"tobi","__proto__":{"x":7}}', done)
+    })
+
+    it('should throw when protoAction is set to error', function (done) {
+      request(createServer({ onProtoPoisoning: 'error' }))
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .send('{"user":"tobi","__proto__":{"x":7}}')
+        .expect(400, '[entity.parse.failed] Object contains forbidden prototype property', done)
+    })
+  
+    it('should remove prototype poisoning when protoAction is set to remove', function (done) {
+      request(createServer({ onProtoPoisoning: 'remove' }))
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .send('{"user":"tobi","__proto__":{"x":7}}')
+        .expect(200, '{"user":"tobi"}', done)
+    })
+  })
 })
 
 function createServer (opts) {


### PR DESCRIPTION
Users of this middleware are given the option to control prototype poisoning
closes: #347