### PR TITLE
Generic Parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,6 @@ function parse(buffer, charset) {
 - **IMPORTANT**: This function MUST be synchronous and return the parsed result directly
   - It cannot be an `async` function
   - It cannot return a Promise
-  - For async parsing libraries, you'll need to use a synchronous alternative
 
 Your parse function will be called even for empty bodies (with a zero-length buffer), but not for requests with no body concept (like GET requests).
 
@@ -565,7 +564,7 @@ Create a custom middleware for parsing XML requests:
 ```js
 const express = require('express')
 const bodyParser = require('body-parser')
-const xmljs = require('xml-js')  // Uses a synchronous XML parser
+const xmljs = require('xml-js')
 
 const app = express()
 
@@ -577,13 +576,11 @@ const xmlParser = bodyParser.generic({
   // Set limits to prevent abuse
   limit: '500kb',
   
-  // Custom synchronous parser function
   parse: function(buf, charset) {
     // Handle empty body case
     if (buf.length === 0) return {}
     
     try {
-      // Convert XML to JS object with configuration
       const result = xmljs.xml2js(buf.toString(charset), {
         compact: true,
         trim: true,
@@ -591,7 +588,6 @@ const xmlParser = bodyParser.generic({
       })
       return result
     } catch (err) {
-      // Standardize parsing errors
       const error = new Error(`Invalid XML: ${err.message}`)
       error.status = 400
       throw error
@@ -676,7 +672,6 @@ const app = express()
 
 // Use with default options
 app.post('/api/csv', csvParser(), function(req, res) {
-  // req.body will have { headers: [...], rows: [...] } structure
   res.json({
     rowCount: req.body.rows.length,
     data: req.body
@@ -686,8 +681,8 @@ app.post('/api/csv', csvParser(), function(req, res) {
 // Or with custom options
 app.post('/api/customcsv', csvParser({
   limit: '250kb',
-  delimiter: ';',     // Use semicolon as delimiter
-  hasHeaders: true    // First row contains column names
+  delimiter: ';',
+  hasHeaders: true
 }), function(req, res) {
   res.json(req.body)
 })

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@
  * @property {function} raw
  * @property {function} text
  * @property {function} urlencoded
+ * @property {function} generic
  */
 
 /**
@@ -64,6 +65,17 @@ Object.defineProperty(exports, 'urlencoded', {
   configurable: true,
   enumerable: true,
   get: () => require('./lib/types/urlencoded')
+})
+
+/**
+ * Generic parser for custom body formats.
+ * @public
+ */
+
+Object.defineProperty(exports, 'generic', {
+  configurable: true,
+  enumerable: true,
+  get: () => require('./lib/generic')
 })
 
 /**

--- a/lib/generic.js
+++ b/lib/generic.js
@@ -1,0 +1,149 @@
+/*!
+ * body-parser
+ * Copyright(c) 2014 Jonathan Ong
+ * Copyright(c) 2014-2015 Douglas Christopher Wilson
+ * MIT Licensed
+ */
+
+'use strict'
+
+/**
+ * Module dependencies.
+ * @private
+ */
+
+const contentType = require('content-type')
+const createError = require('http-errors')
+const debug = require('debug')('body-parser:generic')
+const { isFinished } = require('on-finished')
+const read = require('./read')
+const typeis = require('type-is')
+const utils = require('./utils')
+
+/**
+ * Module exports.
+ * @public
+ */
+
+module.exports = generic
+
+/**
+ * Create a middleware to parse request bodies.
+ *
+ * @param {Object} [options]
+ * @param {Function} [options.parse] Function to parse body (required)
+ * @param {String|Function} [options.type] Request content-type to match (required)
+ * @param {String|Number} [options.limit] Maximum request body size
+ * @param {Boolean} [options.inflate] Enable handling compressed bodies
+ * @param {Function} [options.verify] Verify body content
+ * @param {String} [options.defaultCharset] Default charset when not specified
+ * @param {String} [options.charset] Expected charset (will respond with 415 if not matched)
+ * @return {Function} middleware
+ * @public
+ */
+
+function generic (options) {
+  // === STEP 0: VALIDATE OPTIONS ===
+  const opts = options || {}
+
+  if (typeof opts.parse !== 'function') {
+    throw new TypeError('option parse must be a function')
+  }
+
+  // For generic parser, type is a required option
+  if (opts.type === undefined) {
+    throw new TypeError('option type must be specified for generic parser')
+  }
+
+  // === CONFIGURE PARSER OPTIONS ===
+  const defaultCharset = opts.defaultCharset || 'utf-8'
+
+  // Use the common options normalization function
+  const { inflate, limit, verify, shouldParse } = utils.normalizeOptions(opts, opts.type)
+
+  debug('creating parser with options %j', {
+    limit,
+    inflate,
+    defaultCharset
+  })
+
+  // Return middleware function
+  return function genericParser (req, res, next) {
+    // === STEP 1: REQUEST EVALUATION ===
+    if (isFinished(req)) {
+      debug('request already finished')
+      next()
+      return
+    }
+
+    // Initialize body property if not exists
+    if (!('body' in req)) {
+      debug('initializing body property')
+      req.body = undefined
+    }
+
+    // Skip empty bodies
+    if (!typeis.hasBody(req)) {
+      debug('skip empty body')
+      next()
+      return
+    }
+
+    // === STEP 2: CONTENT TYPE MATCHING ===
+    debug('content-type %j', req.headers['content-type'])
+
+    if (!shouldParse(req)) {
+      debug('skip parsing: content-type mismatch')
+      next()
+      return
+    }
+
+    // === STEP 3: CHARSET DETECTION ===
+    let charset
+    try {
+      const ct = contentType.parse(req)
+      charset = (ct.parameters.charset || defaultCharset).toLowerCase()
+      debug('charset %s', charset)
+    } catch (err) {
+      debug('charset error: %s', err.message)
+      charset = defaultCharset
+    }
+
+    // Check if charset is supported
+    if (opts.charset !== undefined && opts.charset !== charset) {
+      debug('unsupported charset %s (expecting %s)', charset, opts.charset)
+      next(createError(415, 'unsupported charset "' + charset.toUpperCase() + '"', {
+        charset: charset,
+        type: 'charset.unsupported'
+      }))
+      return
+    }
+
+    // === STEP 4 & 5: BODY READING AND PARSING ===
+    // The read function handles the actual body reading
+    // and passes the result to our parse function
+    read(req, res, next, function parseBody (buf) {
+      debug('parse %d byte body', buf.length)
+
+      try {
+        // Call the parse function
+        const result = opts.parse(buf, charset)
+        debug('parsed as %o', result)
+        return result
+      } catch (err) {
+        debug('parse error: %s', err.message)
+
+        throw createError(400, err.message, {
+          body: buf.toString().substring(0, 100),
+          charset,
+          type: 'entity.parse.failed'
+        })
+      }
+    }, debug, {
+      encoding: charset,
+      inflate,
+      limit,
+      verify
+    })
+  }
+}

--- a/lib/generic.js
+++ b/lib/generic.js
@@ -33,6 +33,7 @@ module.exports = generic
  * @param {Object} [options]
  * @param {Function} [options.parse] Function to parse body (required). This function:
  *   - Receives (buffer, charset) as arguments
+ *   - Must be synchronous (cannot be async or return a Promise)
  *   - Will be called for requests with empty bodies (zero-length buffer)
  *   - Will NOT be called for requests with no body at all (e.g., typical GET requests)
  *   - Return value becomes req.body

--- a/lib/generic.js
+++ b/lib/generic.js
@@ -31,7 +31,11 @@ module.exports = generic
  * Create a middleware to parse request bodies.
  *
  * @param {Object} [options]
- * @param {Function} [options.parse] Function to parse body (required)
+ * @param {Function} [options.parse] Function to parse body (required). This function:
+ *   - Receives (buffer, charset) as arguments
+ *   - Will be called for requests with empty bodies (zero-length buffer)
+ *   - Will NOT be called for requests with no body at all (e.g., typical GET requests)
+ *   - Return value becomes req.body
  * @param {String|Function} [options.type] Request content-type to match (required)
  * @param {String|Number} [options.limit] Maximum request body size
  * @param {Boolean} [options.inflate] Enable handling compressed bodies
@@ -67,7 +71,6 @@ function generic (options) {
     defaultCharset
   })
 
-  // Return middleware function
   return function genericParser (req, res, next) {
     // === STEP 1: REQUEST EVALUATION ===
     if (isFinished(req)) {

--- a/test/generic.js
+++ b/test/generic.js
@@ -1,0 +1,227 @@
+'use strict'
+
+const assert = require('node:assert')
+const http = require('node:http')
+const request = require('supertest')
+
+const { generic } = require('..')
+
+const PARSERS = {
+  // Reverses the input string
+  reverse: (buf, charset) => buf.toString(charset).split('').reverse().join(''),
+
+  json: (buf, charset) => JSON.parse(buf.toString(charset))
+}
+
+describe('generic()', function () {
+  it('should reject without parse function', function () {
+    assert.throws(function () {
+      generic()
+    }, /option parse must be a function/)
+  })
+
+  it('should reject without type option', function () {
+    assert.throws(function () {
+      generic({ parse: function () {} })
+    }, /option type must be specified for generic parser/)
+  })
+
+  it('should parse text body with custom parser', function (done) {
+    const server = createServer(PARSERS.reverse)
+
+    request(server)
+      .post('/')
+      .set('Content-Type', 'text/plain')
+      .send('hello world')
+      .expect(200, '"dlrow olleh"', done)
+  })
+
+  it('should handle Content-Length: 0', function (done) {
+    const server = createServer(PARSERS.reverse)
+
+    request(server)
+      .get('/')
+      .set('Content-Type', 'text/plain')
+      .set('Content-Length', '0')
+      .expect(200, '""', done)
+  })
+
+  it('should handle empty message-body', function (done) {
+    const server = createServer(PARSERS.reverse)
+
+    request(server)
+      .get('/')
+      .set('Content-Type', 'text/plain')
+      .set('Transfer-Encoding', 'chunked')
+      .expect(200, '""', done)
+  })
+
+  it('should 400 on parser error', function (done) {
+    const server = createServer(function (buf) {
+      throw new Error('parse error')
+    })
+
+    request(server)
+      .post('/')
+      .set('Content-Type', 'text/plain')
+      .send('hello')
+      .expect(400, '[entity.parse.failed] parse error', done)
+  })
+
+  it('should 413 when body too large', function (done) {
+    const server = createServer({ limit: '1kb' }, function (buf, charset) {
+      return buf.toString(charset)
+    })
+
+    const largeText = new Array(1024 * 10 + 1).join('x')
+
+    request(server)
+      .post('/')
+      .set('Content-Type', 'text/plain')
+      .send(largeText)
+      .expect(413, '[entity.too.large] request entity too large', done)
+  })
+
+  it('should match content-type correctly', function (done) {
+    const server = createServer({ type: 'application/vnd.custom+plain' }, function (buf, charset) {
+      return buf.toString(charset)
+    })
+
+    request(server)
+      .post('/')
+      .set('Content-Type', 'application/vnd.custom+plain')
+      .send('custom format')
+      .expect(200, '"custom format"', done)
+  })
+
+  it('should not parse when content-type does not match', function (done) {
+    const server = createServer({ type: 'application/xml' }, function (buf, charset) {
+      return buf.toString(charset)
+    })
+
+    request(server)
+      .post('/')
+      .set('Content-Type', 'application/json')
+      .send('{"hello":"world"}')
+      .expect(200, 'undefined', done)
+  })
+
+  it('should 415 when charset does not match', function (done) {
+    const server = createServer({
+      charset: 'utf-8',
+      type: 'text/plain'
+    }, function (buf, charset) {
+      return buf.toString(charset)
+    })
+
+    request(server)
+      .post('/')
+      .set('Content-Type', 'text/plain; charset=iso-8859-1')
+      .send('hello world')
+      .expect(415, '[charset.unsupported] unsupported charset "ISO-8859-1"', done)
+  })
+
+  describe('with verify option', function () {
+    it('should verify request', function (done) {
+      let verifyCalled = false
+
+      const server = createServer({
+        verify: function (req, res, buf) {
+          verifyCalled = true
+          if (buf[0] === 0x5b) throw new Error('no arrays')
+        },
+        type: 'application/json'
+      }, PARSERS.json)
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .send('{"user":"tobi"}')
+        .expect(200)
+        .end(function (err, res) {
+          if (err) return done(err)
+          assert.strictEqual(verifyCalled, true, 'verify function should be called')
+          assert.strictEqual(res.text, '{"user":"tobi"}')
+          done()
+        })
+    })
+
+    it('should 403 when verification fails', function (done) {
+      let verifyCalled = false
+
+      const server = createServer({
+        verify: function (req, res, buf) {
+          verifyCalled = true
+          if (buf[0] === 0x5b) throw new Error('no arrays')
+        },
+        type: 'application/json'
+      }, PARSERS.json)
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .send('[1,2,3]')
+        .expect(403)
+        .end(function (err, res) {
+          if (err) return done(err)
+          assert.strictEqual(verifyCalled, true, 'verify function should be called')
+          assert.strictEqual(res.text, '[entity.verify.failed] no arrays')
+          done()
+        })
+    })
+
+    it('should not call verify when content-type does not match', function (done) {
+      let verifyCalled = false
+
+      const server = createServer({
+        verify: function (req, res, buf) {
+          verifyCalled = true
+        },
+        type: 'application/json'
+      }, PARSERS.json)
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'text/plain')
+        .send('hello world')
+        .expect(200)
+        .end(function (err, res) {
+          if (err) return done(err)
+          assert.strictEqual(verifyCalled, false, 'verify function should not be called')
+          assert.strictEqual(res.text, 'undefined')
+          done()
+        })
+    })
+  })
+})
+
+function createServer (options, parserImpl) {
+  let parser = parserImpl
+  let opts = options
+  if (typeof options === 'function') {
+    parser = options
+    opts = {}
+  }
+
+  const _parser = parser || PARSERS.json
+
+  // Default type for tests
+  if (!opts.type) {
+    opts.type = 'text/plain'
+  }
+
+  return http.createServer(function (req, res) {
+    generic({ ...opts, parse: _parser })(req, res, function (err) {
+      if (err) {
+        res.statusCode = err.status || 500
+        res.end(err.message ? '[' + err.type + '] ' + err.message : err.type)
+        return
+      }
+
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'text/plain')
+      res.end(typeof req.body === 'undefined' ? 'undefined' : JSON.stringify(req.body))
+    })
+  })
+}
+

--- a/test/generic.js
+++ b/test/generic.js
@@ -37,110 +37,255 @@ describe('generic()', function () {
     }, /option type must be specified for generic parser/)
   })
 
-  it('should parse text body with custom parser', function (done) {
-    const server = createServer(PARSERS.reverse)
+  describe('core functionality', function () {
+    it('should provide request body to parse function and use result as req.body', function (done) {
+      const testResult = { parsed: true, id: Date.now() }
+      const testBody = 'hello parser'
 
-    request(server)
-      .post('/')
-      .set('Content-Type', 'text/plain')
-      .send('hello world')
-      .expect(200, '"dlrow olleh"', done)
-  })
+      const parseFn = trackCall(function (body, charset) {
+        const content = body.toString(charset)
+        assert.strictEqual(content, testBody, 'should receive request body content')
+        return testResult
+      })
 
-  it('should handle Content-Length: 0', function (done) {
-    const server = createServer(PARSERS.reverse)
+      const server = createServer(parseFn)
 
-    request(server)
-      .get('/')
-      .set('Content-Type', 'text/plain')
-      .set('Content-Length', '0')
-      .expect(200, '""', done)
-  })
-
-  it('should handle empty message-body', function (done) {
-    const server = createServer(PARSERS.reverse)
-
-    request(server)
-      .get('/')
-      .set('Content-Type', 'text/plain')
-      .set('Transfer-Encoding', 'chunked')
-      .expect(200, '""', done)
-  })
-
-  it('should 400 on parser error', function (done) {
-    const server = createServer(function (buf) {
-      throw new Error('parse error')
+      request(server)
+        .post('/')
+        .set('Content-Type', 'text/plain')
+        .send(testBody)
+        .expect(200)
+        .end(function (err, res) {
+          if (err) return done(err)
+          assert(parseFn.called(), 'parse function should be called')
+          const body = JSON.parse(res.text)
+          assert.deepStrictEqual(body, testResult, 'parse result should become req.body')
+          done()
+        })
     })
 
-    request(server)
-      .post('/')
-      .set('Content-Type', 'text/plain')
-      .send('hello')
-      .expect(400, '[entity.parse.failed] parse error', done)
+    it('should handle empty body regardless of encoding method', function (done) {
+      let calledWithEmptyBuffer = false
+
+      const parseFn = function (buf, _charset) {
+        calledWithEmptyBuffer = (buf.length === 0)
+        return { empty: true }
+      }
+
+      const server = createServer(parseFn)
+
+      // First test: Content-Length: 0
+      request(server)
+        .get('/')
+        .set('Content-Type', 'text/plain')
+        .set('Content-Length', '0')
+        .expect(200, '{"empty":true}')
+        .end(function (err) {
+          if (err) return done(err)
+          assert(calledWithEmptyBuffer, 'parse function should be called with empty buffer')
+          calledWithEmptyBuffer = false
+
+          // Second test: chunked encoding
+          request(server)
+            .get('/')
+            .set('Content-Type', 'text/plain')
+            .set('Transfer-Encoding', 'chunked')
+            .expect(200, '{"empty":true}')
+            .end(function (err) {
+              if (err) return done(err)
+              assert(calledWithEmptyBuffer, 'parse function should be called with empty buffer')
+              done()
+            })
+        })
+    })
   })
 
-  it('should 413 when body too large', function (done) {
-    const server = createServer({ limit: '1kb' }, function (buf, charset) {
-      return buf.toString(charset)
+  describe('error handling', function () {
+    it('should return 400 for parsing errors', function (done) {
+      const server1 = createServer(function (_buf) {
+        throw new Error('parse error')
+      })
+
+      const server2 = createServer({
+        type: 'application/json'
+      }, PARSERS.json)
+
+      request(server1)
+        .post('/')
+        .set('Content-Type', 'text/plain')
+        .send('hello')
+        .expect(400, '[entity.parse.failed] parse error')
+        .end(function (err) {
+          if (err) return done(err)
+
+          request(server2)
+            .post('/')
+            .set('Content-Type', 'application/json')
+            .send('{"broken": "json')
+            .expect(400)
+            .expect(function (res) {
+              assert(res.text.includes('entity.parse.failed'))
+            })
+            .end(done)
+        })
     })
 
-    const largeText = new Array(1024 * 10 + 1).join('x')
+    it('should 413 when body too large', function (done) {
+      const server = createServer({ limit: '1kb' }, function (buf, charset) {
+        return buf.toString(charset)
+      })
 
-    request(server)
-      .post('/')
-      .set('Content-Type', 'text/plain')
-      .send(largeText)
-      .expect(413, '[entity.too.large] request entity too large', done)
+      const largeText = new Array(1024 * 10 + 1).join('x')
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'text/plain')
+        .send(largeText)
+        .expect(413, '[entity.too.large] request entity too large', done)
+    })
   })
 
-  it('should match content-type correctly', function (done) {
-    const server = createServer({ type: 'application/vnd.custom+plain' }, function (buf, charset) {
-      return buf.toString(charset)
+  describe('content-type matching', function () {
+    it('should match exact content type', function (done) {
+      const server = createServer({
+        type: 'text/markdown'
+      }, _buf => 'markdown matched')
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'text/markdown')
+        .send('# heading')
+        .expect(200, '"markdown matched"', done)
     })
 
-    request(server)
-      .post('/')
-      .set('Content-Type', 'application/vnd.custom+plain')
-      .send('custom format')
-      .expect(200, '"custom format"', done)
-  })
+    it('should match custom media type', function (done) {
+      const server = createServer({
+        type: 'application/vnd.custom+plain'
+      }, function (buf, charset) {
+        return buf.toString(charset)
+      })
 
-  it('should not parse when content-type does not match', function (done) {
-    const server = createServer({ type: 'application/xml' }, function (buf, charset) {
-      return buf.toString(charset)
+      request(server)
+        .post('/')
+        .set('Content-Type', 'application/vnd.custom+plain')
+        .send('custom format')
+        .expect(200, '"custom format"', done)
     })
 
-    request(server)
-      .post('/')
-      .set('Content-Type', 'application/json')
-      .send('{"hello":"world"}')
-      .expect(200, 'undefined', done)
-  })
+    it('should not parse when content-type does not match', function (done) {
+      const server = createServer({
+        type: 'text/markdown'
+      }, _buf => 'should not be called')
 
-  it('should 415 when charset does not match', function (done) {
-    const server = createServer({
-      charset: 'utf-8',
-      type: 'text/plain'
-    }, function (buf, charset) {
-      return buf.toString(charset)
+      request(server)
+        .post('/')
+        .set('Content-Type', 'text/html')
+        .send('<h1>heading</h1>')
+        .expect(200, 'undefined', done)
     })
 
-    request(server)
-      .post('/')
-      .set('Content-Type', 'text/plain; charset=iso-8859-1')
-      .send('hello world')
-      .expect(415, '[charset.unsupported] unsupported charset "ISO-8859-1"', done)
+    it('should handle content-type with parameters besides charset', function (done) {
+      const server = createServer({
+        type: 'text/plain'
+      }, function (buf, charset) {
+        return buf.toString(charset)
+      })
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'text/plain; version=1.0; boundary=something')
+        .send('hello with params')
+        .expect(200, '"hello with params"', done)
+    })
+
+    it('should 415 when charset does not match', function (done) {
+      const server = createServer({
+        charset: 'utf-8',
+        type: 'text/plain'
+      }, function (buf, charset) {
+        return buf.toString(charset)
+      })
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'text/plain; charset=iso-8859-1')
+        .send('hello world')
+        .expect(415, '[charset.unsupported] unsupported charset "ISO-8859-1"', done)
+    })
+
+    describe('with array of types', function () {
+      it('should match first type in array', function (done) {
+        const server = createServer({
+          type: ['application/x-foo', 'application/x-bar']
+        }, _buf => 'multi-type matched')
+
+        request(server)
+          .post('/')
+          .set('Content-Type', 'application/x-foo')
+          .send('foo data')
+          .expect(200, '"multi-type matched"', done)
+      })
+
+      it('should match second type in array', function (done) {
+        const server = createServer({
+          type: ['application/x-foo', 'application/x-bar']
+        }, _buf => 'multi-type matched')
+
+        request(server)
+          .post('/')
+          .set('Content-Type', 'application/x-bar')
+          .send('bar data')
+          .expect(200, '"multi-type matched"', done)
+      })
+    })
+
+    describe('with function type checker', function () {
+      it('should match when function returns true', function (done) {
+        const typeCheckFn = trackCall(function (req) {
+          assert(req && req.headers, 'should be called with request object')
+          return /^text\//.test(req.headers['content-type'])
+        })
+
+        const server = createServer({
+          type: typeCheckFn
+        }, function (buf, charset) {
+          return buf.toString(charset)
+        })
+
+        request(server)
+          .post('/')
+          .set('Content-Type', 'text/plain')
+          .send('custom format')
+          .expect(200)
+          .end(function (err, _res) {
+            if (err) return done(err)
+            assert(typeCheckFn.called(), 'type check function should be called')
+            done()
+          })
+      })
+
+      it('should support custom matching logic', function (done) {
+        const server = createServer({
+          type: req => req.headers['content-type']?.includes('custom')
+        }, _buf => 'function match')
+
+        request(server)
+          .post('/')
+          .set('Content-Type', 'application/custom+type')
+          .send('custom data')
+          .expect(200, '"function match"', done)
+      })
+    })
   })
 
   describe('with verify option', function () {
     it('should verify request', function (done) {
-      let verifyCalled = false
+      const verifyFn = trackCall(function (_req, _res, buf) {
+        if (buf[0] === 0x5b) throw new Error('no arrays')
+      })
 
       const server = createServer({
-        verify: function (req, res, buf) {
-          verifyCalled = true
-          if (buf[0] === 0x5b) throw new Error('no arrays')
-        },
+        verify: verifyFn,
         type: 'application/json'
       }, PARSERS.json)
 
@@ -151,20 +296,19 @@ describe('generic()', function () {
         .expect(200)
         .end(function (err, res) {
           if (err) return done(err)
-          assert.strictEqual(verifyCalled, true, 'verify function should be called')
+          assert.strictEqual(verifyFn.called(), true, 'verify function should be called')
           assert.strictEqual(res.text, '{"user":"tobi"}')
           done()
         })
     })
 
     it('should 403 when verification fails', function (done) {
-      let verifyCalled = false
+      const verifyFn = trackCall(function (_req, _res, buf) {
+        if (buf[0] === 0x5b) throw new Error('no arrays')
+      })
 
       const server = createServer({
-        verify: function (req, res, buf) {
-          verifyCalled = true
-          if (buf[0] === 0x5b) throw new Error('no arrays')
-        },
+        verify: verifyFn,
         type: 'application/json'
       }, PARSERS.json)
 
@@ -175,19 +319,17 @@ describe('generic()', function () {
         .expect(403)
         .end(function (err, res) {
           if (err) return done(err)
-          assert.strictEqual(verifyCalled, true, 'verify function should be called')
+          assert.strictEqual(verifyFn.called(), true, 'verify function should be called')
           assert.strictEqual(res.text, '[entity.verify.failed] no arrays')
           done()
         })
     })
 
     it('should not call verify when content-type does not match', function (done) {
-      let verifyCalled = false
+      const verifyFn = trackCall()
 
       const server = createServer({
-        verify: function (req, res, buf) {
-          verifyCalled = true
-        },
+        verify: verifyFn,
         type: 'application/json'
       }, PARSERS.json)
 
@@ -198,8 +340,50 @@ describe('generic()', function () {
         .expect(200)
         .end(function (err, res) {
           if (err) return done(err)
-          assert.strictEqual(verifyCalled, false, 'verify function should not be called')
+          assert.strictEqual(verifyFn.called(), false, 'verify function should not be called')
           assert.strictEqual(res.text, 'undefined')
+          done()
+        })
+    })
+
+    it('should not call verify when request has no body', function (done) {
+      const verifyFn = trackCall()
+
+      const server = createServer({
+        verify: verifyFn,
+        type: 'application/json'
+      }, PARSERS.json)
+
+      request(server)
+        .get('/')
+        .set('Content-Type', 'application/json')
+        .expect(200)
+        .end(function (err, _res) {
+          if (err) return done(err)
+          assert.strictEqual(verifyFn.called(), false, 'verify function should not be called')
+          done()
+        })
+    })
+
+    // Skipped environment-specific test
+
+    it('should not call verify when charset is not supported', function (done) {
+      const verifyFn = trackCall()
+
+      const server = createServer({
+        verify: verifyFn,
+        charset: 'utf-8',
+        type: 'application/json'
+      }, PARSERS.json)
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'application/json; charset=iso-8859-1')
+        .send('{"test":"value"}')
+        .expect(415)
+        .end(function (err, _res) {
+          if (err) return done(err)
+          assert.strictEqual(verifyFn.called(), false, 'verify function should not be called')
           done()
         })
     })
@@ -215,11 +399,7 @@ function createServer (options, parserImpl) {
   }
 
   const _parser = parser || PARSERS.json
-
-  // Default type for tests
-  if (!opts.type) {
-    opts.type = 'text/plain'
-  }
+  if (!opts.type) opts.type = 'text/plain'
 
   return http.createServer(function (req, res) {
     generic({ ...opts, parse: _parser })(req, res, function (err) {
@@ -235,4 +415,3 @@ function createServer (options, parserImpl) {
     })
   })
 }
-

--- a/test/generic.js
+++ b/test/generic.js
@@ -13,6 +13,17 @@ const PARSERS = {
   json: (buf, charset) => JSON.parse(buf.toString(charset))
 }
 
+// Tracks if a function was called
+function trackCall (fn) {
+  let called = false
+  const wrapped = function (...args) {
+    called = true
+    return fn?.(...args)
+  }
+  wrapped.called = () => called
+  return wrapped
+}
+
 describe('generic()', function () {
   it('should reject without parse function', function () {
     assert.throws(function () {


### PR DESCRIPTION
An attempt at solving for #22 and sketching out what the generic interaface would look like.

This is a draft so we can see the diff cleanly, but it's my intent for Generic ot be hashed out on the `generic` branch.

This is an approach which encapsulates Generic as the only middleware to have a `parser` option. 

Users of generic would be required to bring a `type` and a sync `parse` function