### PR TITLE
ci: update CodeQL config to ignore the test directory

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,6 +41,9 @@ jobs:
         uses: github/codeql-action/init@45775bd8235c68ba998cffa5171334d58593da47 # v3.28.15
         with:
           languages: javascript
+          config: |
+            paths-ignore:
+              - test
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
This PR updates the CodeQL config to exclude the `test` directory from scans. Scanning the `test` directory results in false positives. A long list of false positives makes it harder to interpret the result of CodeQL runs. I think we want to scan user-exectuable code, but not our tests. 