### PR TITLE
Added "Error.captureStackTrace" to avoid overwriting the error stack in JSON parser

### DIFF
--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -68,7 +68,9 @@ function json (options) {
 
       if (first !== '{' && first !== '[') {
         debug('strict violation')
-        throw createStrictSyntaxError(body, first)
+        var err = createStrictSyntaxError(body, first)
+        Error.captureStackTrace(err)
+        throw err
       }
     }
 
@@ -198,9 +200,6 @@ function normalizeJsonSyntaxError (error, obj) {
     }
   }
 
-  // replace stack before message for Node.js 0.10 and below
-  error.stack = obj.stack.replace(error.message, obj.message)
   error.message = obj.message
-
   return error
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 
-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Applying the Error.captureStackTrace suggested by @wesleytodd 