### PR TITLE
deps: bump iconv-lite

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "content-type": "^1.0.5",
     "debug": "^4.4.0",
     "http-errors": "^2.0.0",
-    "iconv-lite": "^0.6.3",
+    "iconv-lite": "ashtuchkin/iconv-lite#0.7.0",
     "on-finished": "^2.4.1",
     "qs": "^6.14.0",
     "raw-body": "^3.0.0",


### PR DESCRIPTION
See https://github.com/ashtuchkin/iconv-lite/pull/334. Since this is like a new major version of the package, Dependabot won’t update it, and also to see how it behaves.

The only change that affects body-parser is https://github.com/ashtuchkin/iconv-lite/pull/328.