### PR TITLE
refactor: optimize raw and text parsers with shared passthrough function

### DIFF
--- a/lib/types/raw.js
+++ b/lib/types/raw.js
@@ -12,7 +12,7 @@
 
 var debug = require('debug')('body-parser:raw')
 var read = require('../read')
-var { normalizeOptions } = require('../utils')
+var { normalizeOptions, passthrough } = require('../utils')
 
 /**
  * Module exports.
@@ -31,12 +31,8 @@ module.exports = raw
 function raw (options) {
   var normalizedOptions = normalizeOptions(options, 'application/octet-stream')
 
-  function parse (buf) {
-    return buf
-  }
-
   return function rawParser (req, res, next) {
-    read(req, res, next, parse, debug, {
+    read(req, res, next, passthrough, debug, {
       ...normalizedOptions,
 
       // Skip charset validation and parse the body as is

--- a/lib/types/text.js
+++ b/lib/types/text.js
@@ -12,7 +12,7 @@
 
 var debug = require('debug')('body-parser:text')
 var read = require('../read')
-var { normalizeOptions } = require('../utils')
+var { normalizeOptions, passthrough } = require('../utils')
 
 /**
  * Module exports.
@@ -31,11 +31,7 @@ module.exports = text
 function text (options) {
   var normalizedOptions = normalizeOptions(options, 'text/plain')
 
-  function parse (buf) {
-    return buf
-  }
-
   return function textParser (req, res, next) {
-    read(req, res, next, parse, debug, normalizedOptions)
+    read(req, res, next, passthrough, debug, normalizedOptions)
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -11,10 +11,10 @@ var typeis = require('type-is')
 /**
  * Module exports.
  */
-
 module.exports = {
   getCharset,
-  normalizeOptions
+  normalizeOptions,
+  passthrough
 }
 
 /**
@@ -82,4 +82,15 @@ function normalizeOptions (options, defaultType) {
     defaultCharset,
     shouldParse
   }
+}
+
+/**
+ * Passthrough function that returns input unchanged.
+ * Used by parsers that don't need to transform the data.
+ *
+ * @param {*} value
+ * @return {*}
+ */
+function passthrough (value) {
+  return value
 }


### PR DESCRIPTION
- Replaces duplicate `parse()` functions in the `raw` and `text` parser that just pass-through the value with a shared passthrough in `utils.js`
- Reduces memory overhead when using multiple instances of the same middleware in an application by eliminating function duplication per middleware instance
- Reduces closure overhead by removing captured parse functions
- Allows V8 to optimize and potentially inline the function