### PR TITLE
perf(urlencoded): move empty-body guard to avoid extra function closure

### DIFF
--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -39,13 +39,7 @@ function urlencoded (options) {
   }
 
   // create the appropriate query parser
-  var queryparse = createQueryParser(options)
-
-  function parse (body, encoding) {
-    return body.length
-      ? queryparse(body, encoding)
-      : {}
-  }
+  const parse = createQueryParser(options)
 
   const readOptions = {
     ...normalizedOptions,
@@ -86,7 +80,9 @@ function createQueryParser (options) {
     parameterLimit = parameterLimit | 0
   }
 
-  return function queryparse (body, encoding) {
+  return function parse (body, encoding) {
+    if (!body.length) return {}
+
     var paramCount = parameterCount(body, parameterLimit)
 
     if (paramCount === undefined) {


### PR DESCRIPTION
Inlines the empty-body check into the parser returned by `createQueryParser`, removing the extra wrapper function. The behavior is unchanged but we get a minor perf/alloc win by not creating a extra closure.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
