### PR TITLE
perf: move read options outside parser middlewares

### DIFF
--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -48,7 +48,7 @@ var JSON_SYNTAX_REGEXP = /#+/g
  */
 
 function json (options) {
-  var normalizedOptions = normalizeOptions(options, 'application/json')
+  const normalizedOptions = normalizeOptions(options, 'application/json')
 
   var reviver = options?.reviver
   var strict = options?.strict !== false
@@ -80,13 +80,14 @@ function json (options) {
     }
   }
 
-  return function jsonParser (req, res, next) {
-    read(req, res, next, parse, debug, {
-      ...normalizedOptions,
+  const readOptions = {
+    ...normalizedOptions,
+    // assert charset per RFC 7159 sec 8.1
+    isValidCharset: (charset) => charset.slice(0, 4) === 'utf-'
+  }
 
-      // assert charset per RFC 7159 sec 8.1
-      isValidCharset: (charset) => charset.slice(0, 4) === 'utf-'
-    })
+  return function jsonParser (req, res, next) {
+    read(req, res, next, parse, debug, readOptions)
   }
 }
 

--- a/lib/types/raw.js
+++ b/lib/types/raw.js
@@ -29,14 +29,15 @@ module.exports = raw
  */
 
 function raw (options) {
-  var normalizedOptions = normalizeOptions(options, 'application/octet-stream')
+  const normalizedOptions = normalizeOptions(options, 'application/octet-stream')
+
+  const readOptions = {
+    ...normalizedOptions,
+    // Skip charset validation and parse the body as is
+    skipCharset: true
+  }
 
   return function rawParser (req, res, next) {
-    read(req, res, next, passthrough, debug, {
-      ...normalizedOptions,
-
-      // Skip charset validation and parse the body as is
-      skipCharset: true
-    })
+    read(req, res, next, passthrough, debug, readOptions)
   }
 }

--- a/lib/types/text.js
+++ b/lib/types/text.js
@@ -29,7 +29,7 @@ module.exports = text
  */
 
 function text (options) {
-  var normalizedOptions = normalizeOptions(options, 'text/plain')
+  const normalizedOptions = normalizeOptions(options, 'text/plain')
 
   return function textParser (req, res, next) {
     read(req, res, next, passthrough, debug, normalizedOptions)

--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -33,7 +33,7 @@ module.exports = urlencoded
  */
 
 function urlencoded (options) {
-  var normalizedOptions = normalizeOptions(options, 'application/x-www-form-urlencoded')
+  const normalizedOptions = normalizeOptions(options, 'application/x-www-form-urlencoded')
 
   if (normalizedOptions.defaultCharset !== 'utf-8' && normalizedOptions.defaultCharset !== 'iso-8859-1') {
     throw new TypeError('option defaultCharset must be either utf-8 or iso-8859-1')
@@ -48,13 +48,14 @@ function urlencoded (options) {
       : {}
   }
 
-  return function urlencodedParser (req, res, next) {
-    read(req, res, next, parse, debug, {
-      ...normalizedOptions,
+  const readOptions = {
+    ...normalizedOptions,
+    // assert charset
+    isValidCharset: (charset) => charset === 'utf-8' || charset === 'iso-8859-1'
+  }
 
-      // assert charset
-      isValidCharset: (charset) => charset === 'utf-8' || charset === 'iso-8859-1'
-    })
+  return function urlencodedParser (req, res, next) {
+    read(req, res, next, parse, debug, readOptions)
   }
 }
 


### PR DESCRIPTION
Move options object creation outside the returned parser middlewares to avoid recreating objects on every request.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
