### PR TITLE
Remove history.md from being packaged on publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
   "files": [
     "lib/",
     "LICENSE",
-    "HISTORY.md",
     "index.js"
   ],
   "engines": {


### PR DESCRIPTION
Removed HISTORY.md from the files list in package.json
see https://github.com/expressjs/express/pull/6780