### PR TITLE
feat: generic parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ encoding of the request. The parsing can be aborted by throwing an error.
 
 Returns middleware that only parses `urlencoded` bodies and only looks at
 requests where the `Content-Type` header matches the `type` option. This
-parser accepts only UTF-8 and ISO-8859-1 encodings of the body and supports 
+parser accepts only UTF-8 and ISO-8859-1 encodings of the body and supports
 automatic inflation of `gzip`, `br` (brotli) and `deflate` encodings.
 
 A new `body` object containing the parsed data is populated on the `request`
@@ -341,27 +341,34 @@ The `generic` function takes an `options` object that may contain any of the fol
 
 ##### parse
 
-**Required.** The `parse` function that converts the raw request body buffer into a JavaScript object. This function receives two arguments:
+**Required.** The `parse` function that converts the request body into a JavaScript object. By default, this function receives a decoded request body string and the detected charset:
 
 ```js
-function parse (buffer, charset) {
-  // Convert Buffer to parsed object
+function parse (body, charset) {
+  // Convert body to parsed object
   return parsedObject
 }
 ```
 
-- `buffer`: A Buffer containing the raw request body
+- `body`: A string containing the decoded request body
 - `charset`: The detected charset from Content-Type header or defaultCharset
 - Return value becomes `req.body`
 - **IMPORTANT**: This function MUST be synchronous and return the parsed result directly
   - It cannot be an `async` function
   - It cannot return a Promise
 
-Your parse function will be called even for empty bodies (with a zero-length buffer), but not for requests with no body concept (like GET requests).
+Your parse function will be called even for empty bodies (with a zero-length buffer or string), but not for requests with no body concept (like GET requests).
 
 For empty bodies, consider following these conventions:
 - For JSON-like parsers: Return `{}` (empty object)
 - For text/raw-like parsers: Return the empty buffer/string as-is
+
+##### parseAs
+
+Controls the body value passed as the first argument to the `parse` function. Defaults to `string`.
+
+- `string`: `parse(body, charset)` receives the request body decoded with the detected charset
+- `buffer`: `parse(body, charset)` receives the raw request body as a `Buffer`
 
 ##### type
 
@@ -369,7 +376,7 @@ For empty bodies, consider following these conventions:
 
 - A string mime type (like `application/xml`)
 - An extension name (like `xml`)
-- A mime type with a wildcard (like `*/xml`) 
+- A mime type with a wildcard (like `*/xml`)
 - An array of any of the above
 - A function that takes a request and returns a boolean
 
@@ -382,7 +389,7 @@ Specify the default character set for the content if the charset is not specifie
 ##### charset
 
 If specified, the charset of the request must match this option. If the request charset doesn't match, a 415 Unsupported Media Type error is returned.
-This option can be: 
+This option can be:
 
 - A string charset (like `utf-8`)
 - An array of string charsets (like `['utf-8', 'utf-16']`)
@@ -602,15 +609,15 @@ const xmlParser = bodyParser.generic({
   // Set limits to prevent abuse
   limit: '500kb',
 
-  // Validate that only 'utf-8' encoded responses are accepted
+  // Validate that only 'utf-8' encoded requests are accepted
   charset: 'utf-8',
 
-  parse: function (buf, charset) {
+  parse: function (body) {
     // Handle empty body case
-    if (buf.length === 0) return {}
+    if (body.length === 0) return {}
 
     try {
-      const result = xmljs.xml2js(buf.toString(charset), {
+      const result = xmljs.xml2js(body, {
         compact: true,
         trim: true,
         nativeType: true
@@ -652,13 +659,12 @@ function csvParser (options) {
     verify: opts.verify,
     charset: 'utf-8',
 
-    parse: function (buf, charset) {
+    parse: function (body) {
       // Handle empty body
-      if (buf.length === 0) return { rows: [] }
+      if (body.length === 0) return { rows: [] }
 
       try {
-        const csvText = buf.toString(charset)
-        const lines = csvText.split(/\r?\n/).filter(line => line.trim())
+        const lines = body.split(/\r?\n/).filter(line => line.trim())
 
         if (lines.length === 0) return { rows: [] }
 

--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@
  * @property {Function} raw Raw parser
  * @property {Function} text Text parser
  * @property {Function} urlencoded URL-encoded parser
+ * @property {Function} generic Generic parser for custom body formats
  */
 
 /**
@@ -43,6 +44,12 @@ exports.text = require('./lib/types/text')
  * @public
  */
 exports.urlencoded = require('./lib/types/urlencoded')
+
+/**
+ * Generic parser for custom body formats.
+ * @public
+ */
+exports.generic = require('./lib/generic')
 
 /**
  * Create a middleware to parse json and urlencoded bodies.

--- a/lib/generic.js
+++ b/lib/generic.js
@@ -1,0 +1,104 @@
+'use strict'
+
+/**
+ * Module dependencies.
+ * @private
+ */
+
+const createError = require('http-errors')
+const debug = require('debug')('body-parser:generic')
+const read = require('./read')
+const { normalizeOptions } = require('./utils')
+
+/**
+ * Module exports.
+ * @public
+ */
+
+module.exports = generic
+
+/**
+ * Create a middleware to parse request bodies.
+ *
+ * @param {Object} [options]
+ * @param {Function} [options.parse] Function to parse body (required). This function:
+ *   - Receives (buffer, charset) as arguments
+ *   - Must be synchronous (cannot be async or return a Promise)
+ *   - Will be called for requests with empty bodies (zero-length buffer)
+ *   - Will NOT be called for requests with no body at all (e.g., typical GET requests)
+ *   - Return value becomes req.body
+ * @param {String|String[]|Function} [options.type] Request content-type to match (required)
+ * @param {String|Number} [options.limit] Maximum request body size
+ * @param {Boolean} [options.inflate] Enable handling compressed bodies
+ * @param {Function} [options.verify] Verify body content
+ * @param {String} [options.defaultCharset] Default charset when not specified
+ * @param {String|String[]|Function} [options.charset] Expected charset(s) or function which returns a boolean (will respond with 415 if not matched)
+ * @returns {Function} middleware
+ * @public
+ */
+
+function generic (options) {
+  const opts = options || {}
+
+  if (typeof opts.parse !== 'function') {
+    throw new TypeError('option parse must be a function')
+  }
+
+  // For generic parser, type is a required option
+  if (opts.type === undefined || (typeof opts.type !== 'string' && typeof opts.type !== 'function' && !Array.isArray(opts.type))) {
+    throw new TypeError('option type must be specified for generic parser')
+  }
+
+  // Use the common options normalization function
+  const normalizedOptions = normalizeOptions(opts, opts.type)
+
+  debug('creating parser with options %j', {
+    limit: normalizedOptions.limit,
+    inflate: normalizedOptions.inflate,
+    defaultCharset: normalizedOptions.defaultCharset
+  })
+
+  let isValidCharset
+  if (typeof opts.charset === 'string') {
+    const expectedCharset = opts.charset.toLowerCase()
+    isValidCharset = function isValidCharset (charset) {
+      return charset === expectedCharset
+    }
+  } else if (Array.isArray(opts.charset)) {
+    const expectedCharsets = opts.charset.map((v) => String(v).toLowerCase())
+    isValidCharset = function isValidCharset (charset) {
+      return expectedCharsets.includes(charset)
+    }
+  } else if (typeof opts.charset === 'function') {
+    isValidCharset = opts.charset
+  }
+
+  const readOptions = {
+    ...normalizedOptions,
+    isValidCharset,
+    returnBuffer: true
+  }
+
+  function wrappedParse (body, charset) {
+    debug('parse %d byte body', body.length)
+
+    try {
+      // Call the parse function
+      const result = opts.parse(body, charset)
+      debug('parsed as %o', result)
+      return result
+    } catch (err) {
+      debug('parse error: %s', err.message)
+
+      throw createError(400, err.message, {
+        body: body.toString().substring(0, 100),
+        charset,
+        type: 'entity.parse.failed'
+      })
+    }
+  }
+
+  return function genericParser (req, res, next) {
+    read(req, res, next, wrappedParse, debug, readOptions)
+  }
+}

--- a/lib/generic.js
+++ b/lib/generic.js
@@ -22,9 +22,9 @@ module.exports = generic
  *
  * @param {Object} [options]
  * @param {Function} [options.parse] Function to parse body (required). This function:
- *   - Receives (buffer, charset) as arguments
+ *   - Receives (body, charset) as arguments
  *   - Must be synchronous (cannot be async or return a Promise)
- *   - Will be called for requests with empty bodies (zero-length buffer)
+ *   - Will be called for requests with empty bodies (zero-length string/Buffer)
  *   - Will NOT be called for requests with no body at all (e.g., typical GET requests)
  *   - Return value becomes req.body
  * @param {String|String[]|Function} [options.type] Request content-type to match (required)
@@ -33,6 +33,7 @@ module.exports = generic
  * @param {Function} [options.verify] Verify body content
  * @param {String} [options.defaultCharset] Default charset when not specified
  * @param {String|String[]|Function} [options.charset] Expected charset(s) or function which returns a boolean (will respond with 415 if not matched)
+ * @param {String} [options.parseAs] Whether parse receives "buffer" or "string" body
  * @returns {Function} middleware
  * @public
  */
@@ -49,13 +50,22 @@ function generic (options) {
     throw new TypeError('option type must be specified for generic parser')
   }
 
+  const parseAs = opts.parseAs === undefined
+    ? 'string'
+    : opts.parseAs
+
+  if (parseAs !== 'buffer' && parseAs !== 'string') {
+    throw new TypeError('option parseAs must be either "buffer" or "string"')
+  }
+
   // Use the common options normalization function
   const normalizedOptions = normalizeOptions(opts, opts.type)
 
   debug('creating parser with options %j', {
     limit: normalizedOptions.limit,
     inflate: normalizedOptions.inflate,
-    defaultCharset: normalizedOptions.defaultCharset
+    defaultCharset: normalizedOptions.defaultCharset,
+    parseAs
   })
 
   let isValidCharset
@@ -76,11 +86,11 @@ function generic (options) {
   const readOptions = {
     ...normalizedOptions,
     isValidCharset,
-    returnBuffer: true
+    returnBuffer: parseAs === 'buffer'
   }
 
   function wrappedParse (body, charset) {
-    debug('parse %d byte body', body.length)
+    debug('parse body with length %d', body.length)
 
     try {
       // Call the parse function

--- a/lib/read.js
+++ b/lib/read.js
@@ -96,7 +96,7 @@ function read (req, res, next, parse, debug, options) {
 
   // set raw-body options
   opts.length = length
-  opts.encoding = verify
+  opts.encoding = verify || options.returnBuffer
     ? null
     : encoding
 
@@ -156,7 +156,7 @@ function read (req, res, next, parse, debug, options) {
     var str = body
     try {
       debug('parse body')
-      str = typeof body !== 'string' && encoding !== null
+      str = typeof body !== 'string' && encoding !== null && options.returnBuffer !== true
         ? iconv.decode(body, encoding)
         : body
       req.body = parse(str, encoding)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "./raw": "./lib/types/raw.js",
     "./text": "./lib/types/text.js",
     "./urlencoded": "./lib/types/urlencoded.js",
+    "./generic": "./lib/generic.js",
     "./lib/*": "./lib/*.js",
     "./lib/*.js": "./lib/*.js",
     "./lib/types/*": "./lib/types/*.js",

--- a/test/generic.js
+++ b/test/generic.js
@@ -1,0 +1,479 @@
+'use strict'
+
+const assert = require('node:assert')
+const http = require('node:http')
+const request = require('supertest')
+
+const { generic } = require('..')
+
+const PARSERS = {
+  // Reverses the input string
+  reverse: (buf, charset) => buf.toString(charset).split('').reverse().join(''),
+
+  json: (buf, charset) => JSON.parse(buf.toString(charset))
+}
+
+// Tracks if a function was called
+function trackCall (fn) {
+  let called = false
+  const wrapped = function (...args) {
+    called = true
+    return fn?.(...args)
+  }
+  wrapped.called = () => called
+  return wrapped
+}
+
+describe('generic()', function () {
+  it('should reject without parse function', function () {
+    assert.throws(function () {
+      generic()
+    }, /option parse must be a function/)
+  })
+
+  it('should reject without type option', function () {
+    assert.throws(function () {
+      generic({ parse: function () {} })
+    }, /option type must be specified for generic parser/)
+  })
+
+  describe('core functionality', function () {
+    it('should provide request body to parse function and use result as req.body', function (done) {
+      const testResult = { parsed: true, id: Date.now() }
+      const testBody = 'hello parser'
+
+      const parseFn = trackCall(function (body, charset) {
+        const content = body.toString(charset)
+        assert.ok(body instanceof Buffer, 'body should be a Buffer')
+        assert.strictEqual(content, testBody, 'should receive request body content')
+        return testResult
+      })
+
+      const server = createServer(parseFn)
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'text/plain')
+        .send(testBody)
+        .expect(200)
+        .end(function (err, res) {
+          if (err) return done(err)
+          assert(parseFn.called(), 'parse function should be called')
+          const body = JSON.parse(res.text)
+          assert.deepStrictEqual(body, testResult, 'parse result should become req.body')
+          done()
+        })
+    })
+
+    describe('request body handling', function () {
+      it('should call parse function with empty buffer for Content-Length: 0', function (done) {
+        const parseFn = trackCall(function (buf, _charset) {
+          assert.ok(buf instanceof Buffer, 'body should be a Buffer')
+          assert.strictEqual(buf.length, 0, 'buffer should be empty')
+          // Return empty object like JSON/URL-encoded parsers do
+          return { empty: true }
+        })
+
+        const server = createServer(parseFn)
+
+        request(server)
+          .post('/') // Using POST with empty body
+          .set('Content-Type', 'text/plain')
+          .set('Content-Length', '0')
+          .expect(200, '{"empty":true}')
+          .end(function (err) {
+            if (err) return done(err)
+            assert(parseFn.called(), 'parse function should be called for empty body')
+            done()
+          })
+      })
+
+      it('should call parse function with empty buffer for chunked encoding', function (done) {
+        const parseFn = trackCall(function (buf, _charset) {
+          assert.ok(buf instanceof Buffer, 'body should be a Buffer')
+          assert.strictEqual(buf.length, 0, 'buffer should be empty')
+          // Return empty object like JSON/URL-encoded parsers do
+          return { empty: true }
+        })
+
+        const server = createServer(parseFn)
+
+        request(server)
+          .post('/') // Using POST with empty body
+          .set('Content-Type', 'text/plain')
+          .set('Transfer-Encoding', 'chunked')
+          .expect(200, '{"empty":true}')
+          .end(function (err) {
+            if (err) return done(err)
+            assert(parseFn.called(), 'parse function should be called for empty body')
+            done()
+          })
+      })
+
+      it('should NOT call parse function for requests with no body concept', function (done) {
+        const parseFn = trackCall(function (buf, _charset) {
+          return { called: true }
+        })
+
+        const server = createServer(parseFn)
+
+        request(server)
+          .get('/') // GET with no body concept
+          .expect(200, 'undefined')
+          .end(function (err) {
+            if (err) return done(err)
+            assert.strictEqual(parseFn.called(), false, 'parse function should not be called for no-body requests')
+            done()
+          })
+      })
+    })
+  })
+
+  describe('error handling', function () {
+    it('should return 400 for parsing errors', function (done) {
+      const server1 = createServer(function (_buf) {
+        throw new Error('parse error')
+      })
+
+      const server2 = createServer({
+        type: 'application/json'
+      }, PARSERS.json)
+
+      request(server1)
+        .post('/')
+        .set('Content-Type', 'text/plain')
+        .send('hello')
+        .expect(400, '[entity.parse.failed] parse error')
+        .end(function (err) {
+          if (err) return done(err)
+
+          request(server2)
+            .post('/')
+            .set('Content-Type', 'application/json')
+            .send('{"broken": "json')
+            .expect(400)
+            .expect(function (res) {
+              assert(res.text.includes('entity.parse.failed'))
+            })
+            .end(done)
+        })
+    })
+
+    it('should 413 when body too large', function (done) {
+      const server = createServer({ limit: '1kb' }, function (buf, charset) {
+        assert.ok(buf instanceof Buffer, 'body should be a Buffer')
+        return buf.toString(charset)
+      })
+
+      const largeText = new Array(1024 * 10 + 1).join('x')
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'text/plain')
+        .send(largeText)
+        .expect(413, '[entity.too.large] request entity too large', done)
+    })
+  })
+
+  describe('content-type matching', function () {
+    it('should match exact content type', function (done) {
+      const server = createServer({
+        type: 'text/markdown'
+      }, _buf => 'markdown matched')
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'text/markdown')
+        .send('# heading')
+        .expect(200, '"markdown matched"', done)
+    })
+
+    it('should match custom media type', function (done) {
+      const server = createServer({
+        type: 'application/vnd.custom+plain'
+      }, function (buf, charset) {
+        return buf.toString(charset)
+      })
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'application/vnd.custom+plain')
+        .send('custom format')
+        .expect(200, '"custom format"', done)
+    })
+
+    it('should not parse when content-type does not match', function (done) {
+      const server = createServer({
+        type: 'text/markdown'
+      }, _buf => 'should not be called')
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'text/html')
+        .send('<h1>heading</h1>')
+        .expect(200, 'undefined', done)
+    })
+
+    it('should handle content-type with parameters besides charset', function (done) {
+      const server = createServer({
+        type: 'text/plain'
+      }, function (buf, charset) {
+        return buf.toString(charset)
+      })
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'text/plain; version=1.0; boundary=something')
+        .send('hello with params')
+        .expect(200, '"hello with params"', done)
+    })
+
+    it('should 415 when charset does not match (string)', function (done) {
+      const server = createServer({
+        charset: 'utf-8',
+        type: 'text/plain'
+      }, function (buf, charset) {
+        return buf.toString(charset)
+      })
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'text/plain; charset=iso-8859-1')
+        .send('hello world')
+        .expect(415, '[charset.unsupported] unsupported charset "ISO-8859-1"', done)
+    })
+
+    it('should 415 when charset does not match (array)', function (done) {
+      const server = createServer({
+        charset: ['utf-8', 'utf-16'],
+        type: 'text/plain'
+      }, function (buf, charset) {
+        return buf.toString(charset)
+      })
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'text/plain; charset=iso-8859-1')
+        .send('hello world')
+        .expect(415, '[charset.unsupported] unsupported charset "ISO-8859-1"', done)
+    })
+
+    it('should 415 when charset does not match (function)', function (done) {
+      const server = createServer({
+        charset: function (charset) {
+          return charset === 'utf-8'
+        },
+        type: 'text/plain'
+      }, function (buf, charset) {
+        return buf.toString(charset)
+      })
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'text/plain; charset=iso-8859-1')
+        .send('hello world')
+        .expect(415, '[charset.unsupported] unsupported charset "ISO-8859-1"', done)
+    })
+
+    describe('with array of types', function () {
+      it('should match first type in array', function (done) {
+        const server = createServer({
+          type: ['application/x-foo', 'application/x-bar']
+        }, _buf => 'multi-type matched')
+
+        request(server)
+          .post('/')
+          .set('Content-Type', 'application/x-foo')
+          .send('foo data')
+          .expect(200, '"multi-type matched"', done)
+      })
+
+      it('should match second type in array', function (done) {
+        const server = createServer({
+          type: ['application/x-foo', 'application/x-bar']
+        }, _buf => 'multi-type matched')
+
+        request(server)
+          .post('/')
+          .set('Content-Type', 'application/x-bar')
+          .send('bar data')
+          .expect(200, '"multi-type matched"', done)
+      })
+    })
+
+    describe('with function type checker', function () {
+      it('should match when function returns true', function (done) {
+        const typeCheckFn = trackCall(function (req) {
+          assert(req && req.headers, 'should be called with request object')
+          return /^text\//.test(req.headers['content-type'])
+        })
+
+        const server = createServer({
+          type: typeCheckFn
+        }, function (buf, charset) {
+          return buf.toString(charset)
+        })
+
+        request(server)
+          .post('/')
+          .set('Content-Type', 'text/plain')
+          .send('custom format')
+          .expect(200)
+          .end(function (err, _res) {
+            if (err) return done(err)
+            assert(typeCheckFn.called(), 'type check function should be called')
+            done()
+          })
+      })
+
+      it('should support custom matching logic', function (done) {
+        const server = createServer({
+          type: req => req.headers['content-type']?.includes('custom')
+        }, _buf => 'function match')
+
+        request(server)
+          .post('/')
+          .set('Content-Type', 'application/custom+type')
+          .send('custom data')
+          .expect(200, '"function match"', done)
+      })
+    })
+  })
+
+  describe('with verify option', function () {
+    it('should verify request', function (done) {
+      const verifyFn = trackCall(function (_req, _res, buf) {
+        if (buf[0] === 0x5b) throw new Error('no arrays')
+      })
+
+      const server = createServer({
+        verify: verifyFn,
+        type: 'application/json'
+      }, PARSERS.json)
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .send('{"user":"tobi"}')
+        .expect(200)
+        .end(function (err, res) {
+          if (err) return done(err)
+          assert.strictEqual(verifyFn.called(), true, 'verify function should be called')
+          assert.strictEqual(res.text, '{"user":"tobi"}')
+          done()
+        })
+    })
+
+    it('should 403 when verification fails', function (done) {
+      const verifyFn = trackCall(function (_req, _res, buf) {
+        if (buf[0] === 0x5b) throw new Error('no arrays')
+      })
+
+      const server = createServer({
+        verify: verifyFn,
+        type: 'application/json'
+      }, PARSERS.json)
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'application/json')
+        .send('[1,2,3]')
+        .expect(403)
+        .end(function (err, res) {
+          if (err) return done(err)
+          assert.strictEqual(verifyFn.called(), true, 'verify function should be called')
+          assert.strictEqual(res.text, '[entity.verify.failed] no arrays')
+          done()
+        })
+    })
+
+    it('should not call verify when content-type does not match', function (done) {
+      const verifyFn = trackCall()
+
+      const server = createServer({
+        verify: verifyFn,
+        type: 'application/json'
+      }, PARSERS.json)
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'text/plain')
+        .send('hello world')
+        .expect(200)
+        .end(function (err, res) {
+          if (err) return done(err)
+          assert.strictEqual(verifyFn.called(), false, 'verify function should not be called')
+          assert.strictEqual(res.text, 'undefined')
+          done()
+        })
+    })
+
+    it('should not call verify when request has no body', function (done) {
+      const verifyFn = trackCall()
+
+      const server = createServer({
+        verify: verifyFn,
+        type: 'application/json'
+      }, PARSERS.json)
+
+      request(server)
+        .get('/')
+        .set('Content-Type', 'application/json')
+        .expect(200)
+        .end(function (err, _res) {
+          if (err) return done(err)
+          assert.strictEqual(verifyFn.called(), false, 'verify function should not be called')
+          done()
+        })
+    })
+
+    // Skipped environment-specific test
+
+    it('should not call verify when charset is not supported', function (done) {
+      const verifyFn = trackCall()
+
+      const server = createServer({
+        verify: verifyFn,
+        charset: 'utf-8',
+        type: 'application/json'
+      }, PARSERS.json)
+
+      request(server)
+        .post('/')
+        .set('Content-Type', 'application/json; charset=iso-8859-1')
+        .send('{"test":"value"}')
+        .expect(415)
+        .end(function (err, _res) {
+          if (err) return done(err)
+          assert.strictEqual(verifyFn.called(), false, 'verify function should not be called')
+          done()
+        })
+    })
+  })
+})
+
+function createServer (options, parserImpl) {
+  let parser = parserImpl
+  let opts = options
+  if (typeof options === 'function') {
+    parser = options
+    opts = {}
+  }
+
+  const _parser = parser || PARSERS.json
+  if (!opts.type) opts.type = 'text/plain'
+
+  return http.createServer(function (req, res) {
+    generic({ ...opts, parse: _parser })(req, res, function (err) {
+      if (err) {
+        res.statusCode = err.status || 500
+        res.end(err.message ? '[' + err.type + '] ' + err.message : err.type)
+        return
+      }
+
+      res.statusCode = 200
+      res.setHeader('Content-Type', 'text/plain')
+      res.end(typeof req.body === 'undefined' ? 'undefined' : JSON.stringify(req.body))
+    })
+  })
+}

--- a/test/generic.js
+++ b/test/generic.js
@@ -1,6 +1,7 @@
 'use strict'
 
 const assert = require('node:assert')
+const iconv = require('iconv-lite')
 const http = require('node:http')
 const request = require('supertest')
 
@@ -8,9 +9,9 @@ const { generic } = require('..')
 
 const PARSERS = {
   // Reverses the input string
-  reverse: (buf, charset) => buf.toString(charset).split('').reverse().join(''),
+  reverse: (body) => body.split('').reverse().join(''),
 
-  json: (buf, charset) => JSON.parse(buf.toString(charset))
+  json: (body) => JSON.parse(body)
 }
 
 // Tracks if a function was called
@@ -37,15 +38,21 @@ describe('generic()', function () {
     }, /option type must be specified for generic parser/)
   })
 
+  it('should reject invalid parseAs option', function () {
+    assert.throws(function () {
+      generic({ parse: function () {}, parseAs: 'json', type: 'text/plain' })
+    }, /option parseAs must be either "buffer" or "string"/)
+  })
+
   describe('core functionality', function () {
     it('should provide request body to parse function and use result as req.body', function (done) {
       const testResult = { parsed: true, id: Date.now() }
       const testBody = 'hello parser'
 
       const parseFn = trackCall(function (body, charset) {
-        const content = body.toString(charset)
-        assert.ok(body instanceof Buffer, 'body should be a Buffer')
-        assert.strictEqual(content, testBody, 'should receive request body content')
+        assert.strictEqual(typeof body, 'string')
+        assert.strictEqual(body, testBody, 'should receive request body content')
+        assert.strictEqual(charset, 'utf-8')
         return testResult
       })
 
@@ -65,11 +72,128 @@ describe('generic()', function () {
         })
     })
 
+    describe('parseAs option', function () {
+      it('should default to string', function (done) {
+        const parseFn = trackCall(function (body, charset) {
+          assert.strictEqual(typeof body, 'string')
+          assert.strictEqual(body, 'hello parser')
+          assert.strictEqual(charset, 'utf-8')
+          return { type: 'string' }
+        })
+
+        const server = createServer(parseFn)
+
+        request(server)
+          .post('/')
+          .set('Content-Type', 'text/plain')
+          .send('hello parser')
+          .expect(200, '{"type":"string"}')
+          .end(function (err) {
+            if (err) return done(err)
+            assert(parseFn.called(), 'parse function should be called')
+            done()
+          })
+      })
+
+      it('should provide buffer when parseAs is buffer', function (done) {
+        const parseFn = trackCall(function (body, charset) {
+          assert.ok(body instanceof Buffer, 'body should be a Buffer')
+          assert.strictEqual(body.toString(charset), 'hello parser')
+          return { type: 'buffer' }
+        })
+
+        const server = createServer({ parseAs: 'buffer' }, parseFn)
+
+        request(server)
+          .post('/')
+          .set('Content-Type', 'text/plain')
+          .send('hello parser')
+          .expect(200, '{"type":"buffer"}')
+          .end(function (err) {
+            if (err) return done(err)
+            assert(parseFn.called(), 'parse function should be called')
+            done()
+          })
+      })
+
+      it('should allow custom parser to decode non-utf-8 buffer when parseAs is buffer', function (done) {
+        const parseFn = trackCall(function (body, charset) {
+          assert.ok(body instanceof Buffer, 'body should be a Buffer')
+          assert.deepStrictEqual([...body], [0x63, 0x61, 0x66, 0xe9])
+          assert.strictEqual(charset, 'iso-8859-1')
+          return { body: iconv.decode(body, charset), charset }
+        })
+
+        const server = createServer({ parseAs: 'buffer' }, parseFn)
+
+        request(server)
+          .post('/')
+          .set('Content-Type', 'text/plain; charset=iso-8859-1')
+          .send(Buffer.from([0x63, 0x61, 0x66, 0xe9]))
+          .expect(200, '{"body":"caf\u00e9","charset":"iso-8859-1"}')
+          .end(function (err) {
+            if (err) return done(err)
+            assert(parseFn.called(), 'parse function should be called')
+            done()
+          })
+      })
+
+      it('should provide decoded string when parseAs is string', function (done) {
+        const parseFn = trackCall(function (body, charset) {
+          assert.strictEqual(typeof body, 'string')
+          assert.strictEqual(body, 'caf\u00e9')
+          assert.strictEqual(charset, 'iso-8859-1')
+          return { body, charset }
+        })
+
+        const server = createServer({ parseAs: 'string' }, parseFn)
+
+        request(server)
+          .post('/')
+          .set('Content-Type', 'text/plain; charset=iso-8859-1')
+          .send(Buffer.from([0x63, 0x61, 0x66, 0xe9]))
+          .expect(200, '{"body":"caf\u00e9","charset":"iso-8859-1"}')
+          .end(function (err) {
+            if (err) return done(err)
+            assert(parseFn.called(), 'parse function should be called')
+            done()
+          })
+      })
+
+      it('should verify raw buffer before decoding parseAs string bodies', function (done) {
+        const verifyFn = trackCall(function (_req, _res, body, charset) {
+          assert.ok(body instanceof Buffer, 'verified body should be a Buffer')
+          assert.deepStrictEqual([...body], [0x63, 0x61, 0x66, 0xe9])
+          assert.strictEqual(charset, 'iso-8859-1')
+        })
+
+        const parseFn = trackCall(function (body, charset) {
+          assert.strictEqual(typeof body, 'string')
+          assert.strictEqual(body, 'caf\u00e9')
+          assert.strictEqual(charset, 'iso-8859-1')
+          return body
+        })
+
+        const server = createServer({ parseAs: 'string', verify: verifyFn }, parseFn)
+
+        request(server)
+          .post('/')
+          .set('Content-Type', 'text/plain; charset=iso-8859-1')
+          .send(Buffer.from([0x63, 0x61, 0x66, 0xe9]))
+          .expect(200, '"caf\u00e9"')
+          .end(function (err) {
+            if (err) return done(err)
+            assert(verifyFn.called(), 'verify function should be called')
+            assert(parseFn.called(), 'parse function should be called')
+            done()
+          })
+      })
+    })
+
     describe('request body handling', function () {
-      it('should call parse function with empty buffer for Content-Length: 0', function (done) {
-        const parseFn = trackCall(function (buf, _charset) {
-          assert.ok(buf instanceof Buffer, 'body should be a Buffer')
-          assert.strictEqual(buf.length, 0, 'buffer should be empty')
+      it('should call parse function with empty string for Content-Length: 0', function (done) {
+        const parseFn = trackCall(function (body, _charset) {
+          assert.strictEqual(body, '')
           // Return empty object like JSON/URL-encoded parsers do
           return { empty: true }
         })
@@ -88,10 +212,9 @@ describe('generic()', function () {
           })
       })
 
-      it('should call parse function with empty buffer for chunked encoding', function (done) {
-        const parseFn = trackCall(function (buf, _charset) {
-          assert.ok(buf instanceof Buffer, 'body should be a Buffer')
-          assert.strictEqual(buf.length, 0, 'buffer should be empty')
+      it('should call parse function with empty string for chunked encoding', function (done) {
+        const parseFn = trackCall(function (body, _charset) {
+          assert.strictEqual(body, '')
           // Return empty object like JSON/URL-encoded parsers do
           return { empty: true }
         })
@@ -111,7 +234,7 @@ describe('generic()', function () {
       })
 
       it('should NOT call parse function for requests with no body concept', function (done) {
-        const parseFn = trackCall(function (buf, _charset) {
+        const parseFn = trackCall(function (_body, _charset) {
           return { called: true }
         })
 
@@ -131,7 +254,7 @@ describe('generic()', function () {
 
   describe('error handling', function () {
     it('should return 400 for parsing errors', function (done) {
-      const server1 = createServer(function (_buf) {
+      const server1 = createServer(function (_body) {
         throw new Error('parse error')
       })
 
@@ -160,9 +283,8 @@ describe('generic()', function () {
     })
 
     it('should 413 when body too large', function (done) {
-      const server = createServer({ limit: '1kb' }, function (buf, charset) {
-        assert.ok(buf instanceof Buffer, 'body should be a Buffer')
-        return buf.toString(charset)
+      const server = createServer({ limit: '1kb' }, function (body) {
+        return body
       })
 
       const largeText = new Array(1024 * 10 + 1).join('x')
@@ -179,7 +301,7 @@ describe('generic()', function () {
     it('should match exact content type', function (done) {
       const server = createServer({
         type: 'text/markdown'
-      }, _buf => 'markdown matched')
+      }, _body => 'markdown matched')
 
       request(server)
         .post('/')
@@ -191,8 +313,8 @@ describe('generic()', function () {
     it('should match custom media type', function (done) {
       const server = createServer({
         type: 'application/vnd.custom+plain'
-      }, function (buf, charset) {
-        return buf.toString(charset)
+      }, function (body) {
+        return body
       })
 
       request(server)
@@ -205,7 +327,7 @@ describe('generic()', function () {
     it('should not parse when content-type does not match', function (done) {
       const server = createServer({
         type: 'text/markdown'
-      }, _buf => 'should not be called')
+      }, _body => 'should not be called')
 
       request(server)
         .post('/')
@@ -217,8 +339,8 @@ describe('generic()', function () {
     it('should handle content-type with parameters besides charset', function (done) {
       const server = createServer({
         type: 'text/plain'
-      }, function (buf, charset) {
-        return buf.toString(charset)
+      }, function (body) {
+        return body
       })
 
       request(server)
@@ -232,8 +354,8 @@ describe('generic()', function () {
       const server = createServer({
         charset: 'utf-8',
         type: 'text/plain'
-      }, function (buf, charset) {
-        return buf.toString(charset)
+      }, function (body) {
+        return body
       })
 
       request(server)
@@ -247,8 +369,8 @@ describe('generic()', function () {
       const server = createServer({
         charset: ['utf-8', 'utf-16'],
         type: 'text/plain'
-      }, function (buf, charset) {
-        return buf.toString(charset)
+      }, function (body) {
+        return body
       })
 
       request(server)
@@ -264,8 +386,8 @@ describe('generic()', function () {
           return charset === 'utf-8'
         },
         type: 'text/plain'
-      }, function (buf, charset) {
-        return buf.toString(charset)
+      }, function (body) {
+        return body
       })
 
       request(server)
@@ -279,7 +401,7 @@ describe('generic()', function () {
       it('should match first type in array', function (done) {
         const server = createServer({
           type: ['application/x-foo', 'application/x-bar']
-        }, _buf => 'multi-type matched')
+        }, _body => 'multi-type matched')
 
         request(server)
           .post('/')
@@ -291,7 +413,7 @@ describe('generic()', function () {
       it('should match second type in array', function (done) {
         const server = createServer({
           type: ['application/x-foo', 'application/x-bar']
-        }, _buf => 'multi-type matched')
+        }, _body => 'multi-type matched')
 
         request(server)
           .post('/')
@@ -310,8 +432,8 @@ describe('generic()', function () {
 
         const server = createServer({
           type: typeCheckFn
-        }, function (buf, charset) {
-          return buf.toString(charset)
+        }, function (body) {
+          return body
         })
 
         request(server)
@@ -329,7 +451,7 @@ describe('generic()', function () {
       it('should support custom matching logic', function (done) {
         const server = createServer({
           type: req => req.headers['content-type']?.includes('custom')
-        }, _buf => 'function match')
+        }, _body => 'function match')
 
         request(server)
           .post('/')


### PR DESCRIPTION
Based on the work by @jonchurch in #606 and previous PRs listed in https://github.com/expressjs/body-parser/issues/22#issuecomment-2660287078. Dicussion on this topic happened in #22.

---------------------
There is one remaining point we need to figure out:

### `parse` function

This PR in its current state passes the body as `Buffer` and the charset to the user provided parse function: 

```js
function customParse(buffer, charset) {
  // will only work if node.js supports this encoding else the user needs to use iconv-lite or similar libraries 
  const stringContent = buffer.toString(charset) 
  // custom parse method
}
```

With this approach we loose the `iconv-lite` decoding and the users would need to do that themselves . Should we instead already decode the body and pass it as string without the charset? Like:

```js
function customParse(decodedBodyAsString) {
  // custom parse method
}
```

I think the most common use-case for the generic parser will be a custom string parser like parsing `csv` or `yaml`. Not some custom binary format. As alternative we could expose an option which switches between passing a Buffer or a already decoded string to the parse function. 

cc @ctcpip @jonchurch @UlisesGascon @bjohansebas 