### PR TITLE
fix: improve limit option validation

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -60,7 +60,7 @@ function normalizeOptions (options, defaultType) {
   }
 
   var inflate = options?.inflate !== false
-  var limit = options?.limit === undefined || options?.limit === null
+  var limit = typeof options?.limit === 'undefined' || options?.limit === null
     ? 102400 // 100kb default
     : bytes.parse(options.limit)
   var type = options?.type || defaultType

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -60,12 +60,16 @@ function normalizeOptions (options, defaultType) {
   }
 
   var inflate = options?.inflate !== false
-  var limit = typeof options?.limit !== 'number'
-    ? bytes.parse(options?.limit || '100kb')
-    : options?.limit
+  var limit = options?.limit === undefined || options?.limit === null
+    ? 102400 // 100kb default
+    : bytes.parse(options.limit)
   var type = options?.type || defaultType
   var verify = options?.verify || false
   var defaultCharset = options?.defaultCharset || 'utf-8'
+
+  if (limit === null) {
+    throw new TypeError(`option limit "${String(options.limit)}" is invalid`)
+  }
 
   if (verify !== false && typeof verify !== 'function') {
     throw new TypeError('option verify must be function')

--- a/test/utils.js
+++ b/test/utils.js
@@ -71,6 +71,21 @@ describe('normalizeOptions(options, defaultType)', () => {
         assert.strictEqual(result.limit, 100 * 1024) // 100kb in bytes
       })
 
+      it('should return the default limit if limit is undefined', () => {
+        const result = normalizeOptions({ limit: undefined }, 'application/json')
+        assert.strictEqual(result.limit, 100 * 1024) // 100kb in bytes
+      })
+
+      it('should return the default limit if limit is null', () => {
+        const result = normalizeOptions({ limit: null }, 'application/json')
+        assert.strictEqual(result.limit, 100 * 1024) // 100kb in bytes
+      })
+
+      it('should accept zero as valid limit', () => {
+        const result = normalizeOptions({ limit: 0 }, 'application/json')
+        assert.strictEqual(result.limit, 0)
+      })
+
       it('should accept a number limit', () => {
         const result = normalizeOptions({ limit: 1234 }, 'application/json')
         assert.strictEqual(result.limit, 1234)
@@ -81,9 +96,39 @@ describe('normalizeOptions(options, defaultType)', () => {
         assert.strictEqual(result.limit, 200 * 1024) // 200kb in bytes
       })
 
-      it('should return null for an invalid limit', () => {
-        const result = normalizeOptions({ limit: 'invalid' }, 'application/json')
-        assert.strictEqual(result.limit, null)
+      it('should parse a string limit without a unit', () => {
+        const result = normalizeOptions({ limit: '200' }, 'application/json')
+        assert.strictEqual(result.limit, 200) // 200 bytes
+      })
+
+      it('should throw an error for an invalid string limit', () => {
+        assert.throws(() => {
+          normalizeOptions({ limit: 'invalid' }, 'application/json')
+        }, /option limit "invalid" is invalid/)
+        assert.throws(() => {
+          normalizeOptions({ limit: '' }, 'application/json')
+        }, /option limit "" is invalid/)
+      })
+
+      it('should throw an error for a NaN limit', () => {
+        assert.throws(() => {
+          normalizeOptions({ limit: NaN }, 'application/json')
+        }, /option limit "NaN" is invalid/)
+      })
+
+      it('should throw an error for a boolean limit', () => {
+        assert.throws(() => {
+          normalizeOptions({ limit: true }, 'application/json')
+        }, /option limit "true" is invalid/)
+        assert.throws(() => {
+          normalizeOptions({ limit: false }, 'application/json')
+        }, /option limit "false" is invalid/)
+      })
+
+      it('should throw an error for an object limit', () => {
+        assert.throws(() => {
+          normalizeOptions({ limit: { foo: 'bar' } }, 'application/json')
+        }, /option limit "\[object Object\]" is invalid/)
       })
     })
 


### PR DESCRIPTION
This PR fixes an issue where invalid `limit` options were silently accepted and effectively disabled request size limit enforcement.

Currently, when a user passed an invalid value (such as an unparseable string or NaN), `bytes.parse()` would return `null`, causing the request size limit validation to be skipped entirely. This happened without any error or warning, leaving users unaware that the configured limit was not being applied.

This PR makes the behavior explicit and predictable: `null` and `undefined` fall back to the default limit (`100kb`), valid values continue to work as before, and invalid values now throw a clear error instead of silently disabling the limit. This prevents misconfiguration and ensures request size limits are always enforced as expected.

This PR represents one of two possible approaches: either throwing an Error or logging a warning when an invalid option is provided. Throwing an Error seemed preferable, as it fails fast and makes configuration issues immediately visible.

At the moment there is also no explicit way to disable request size limit validation entirely. A possible follow-up for the next major version could be to change the behavior so that passing `null` explicitly disables the request limit check.