### PR TITLE
refactor: move getCharset helper to only usage

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -17,7 +17,7 @@ const iconv = require('iconv-lite')
 const onFinished = require('on-finished')
 const zlib = require('node:zlib')
 const hasBody = require('type-is').hasBody
-const { getCharset } = require('./utils')
+const contentType = require('content-type')
 
 /**
  * Module exports.
@@ -244,4 +244,17 @@ function dump (req, callback) {
     onFinished(req, callback)
     req.resume()
   }
+}
+
+/**
+ * Get the charset of a request.
+ *
+ * @param {Object} req
+ * @returns {string | undefined}
+ * @private
+ */
+function getCharset (req) {
+  const header = req.headers['content-type']
+  if (!header) return undefined
+  return contentType.parse(header).parameters.charset?.toLowerCase()
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,29 +5,14 @@
  */
 
 const bytes = require('bytes')
-const contentType = require('content-type')
 const typeis = require('type-is')
 
 /**
  * Module exports.
  */
 module.exports = {
-  getCharset,
   normalizeOptions,
   passthrough
-}
-
-/**
- * Get the charset of a request.
- *
- * @param {Object} req
- * @returns {string | undefined}
- * @private
- */
-function getCharset (req) {
-  const header = req.headers['content-type']
-  if (!header) return undefined
-  return contentType.parse(header).parameters.charset?.toLowerCase()
 }
 
 /**


### PR DESCRIPTION
...and uses optional chaining. In theory it short-circuits faster and by that avoids the empty string allocation and `.toLowerCase()` call. But this is only in theory and probably highly optimized in engines.

Same ideas as @Ayoub-Mabrouk in #557.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
