### PR TITLE
Release: 1.20.5

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-Unreleased
+1.20.5 / 2026-04-24
 ===================
 * refactor(json): simplify strict mode error string construction 
 * fix: extended urlencoded parsing of arrays with >100 elements (#716)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "body-parser",
   "description": "Node.js body parsing middleware",
-  "version": "1.20.4",
+  "version": "1.20.5",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",
     "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)"


### PR DESCRIPTION
## Notes
- Closes #715 

## What's included in the `HISTORY.md` 

```
1.20.5 / 2026-04-24
===================
* refactor(json): simplify strict mode error string construction 
* fix: extended urlencoded parsing of arrays with >100 elements (#716)
* deps: qs@~6.15.1
```

## What's Changed

Fix extended urlencoded parser returning objects instead of arrays for large array inputs (> 100) on qs@6.14.2+. 
Also bumps qs to `~6.15.1`

## New Contributors
* @abhu85  made their first contribution in https://github.com/expressjs/body-parser/pull/716

Special thanks to triager @krzysdz for keeping this on our radar and effectively triaging the specific issue!

**Full Changelog**: https://github.com/expressjs/body-parser/compare/1.20.4...1.x

