### PR TITLE
deps(qs): bump qs to 6.15.1

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,7 +2,7 @@ Unreleased
 ===================
 * refactor(json): simplify strict mode error string construction 
 * fix: extended urlencoded parsing of arrays with >100 elements (#716)
-* deps: qs@~6.14.2
+* deps: qs@~6.15.1
 
 1.20.4 / 2025-12-01
 ===================

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "http-errors": "~2.0.1",
     "iconv-lite": "~0.4.24",
     "on-finished": "~2.4.1",
-    "qs": "~6.14.2",
+    "qs": "~6.15.1",
     "raw-body": "~2.5.3",
     "type-is": "~1.6.18",
     "unpipe": "~1.0.0"


### PR DESCRIPTION
While prepping #721 which had a bump to the patch version of qs to account for a change in qs (see #715) I realized we can just bump to the next minor without any impact to us. 

This PR bumps qs in the 1.x line from 6.14.x minor to ~6.15.1

There shouldnt be anything in the qs changelog since the 6.14.x releases which impacts us, beyond what was already accounted for in #716 

[qs changelog](https://github.com/ljharb/qs/blob/main/CHANGELOG.md#6151)