### PR TITLE
refactor: switch to const/let and enable eslint no-var rule

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -9,3 +9,4 @@ overrides:
     processor: 'markdown/markdown'
 rules:
   no-param-reassign: error
+  no-var: error

--- a/lib/read.js
+++ b/lib/read.js
@@ -11,13 +11,13 @@
  * @private
  */
 
-var createError = require('http-errors')
-var getBody = require('raw-body')
-var iconv = require('iconv-lite')
-var onFinished = require('on-finished')
-var zlib = require('node:zlib')
-var hasBody = require('type-is').hasBody
-var { getCharset } = require('./utils')
+const createError = require('http-errors')
+const getBody = require('raw-body')
+const iconv = require('iconv-lite')
+const onFinished = require('on-finished')
+const zlib = require('node:zlib')
+const hasBody = require('type-is').hasBody
+const { getCharset } = require('./utils')
 
 /**
  * Module exports.
@@ -63,7 +63,7 @@ function read (req, res, next, parse, debug, options) {
     return
   }
 
-  var encoding = null
+  let encoding = null
   if (options?.skipCharset !== true) {
     encoding = getCharset(req) || options.defaultCharset
 
@@ -78,12 +78,12 @@ function read (req, res, next, parse, debug, options) {
     }
   }
 
-  var length
-  var opts = options
-  var stream
+  let length
+  const opts = options
+  let stream
 
   // read options
-  var verify = opts.verify
+  const verify = opts.verify
 
   try {
     // get the content stream
@@ -112,7 +112,7 @@ function read (req, res, next, parse, debug, options) {
   debug('read body')
   getBody(stream, opts, function (error, body) {
     if (error) {
-      var _error
+      let _error
 
       if (error.type === 'encoding.unsupported') {
         // echo back charset
@@ -153,7 +153,7 @@ function read (req, res, next, parse, debug, options) {
     }
 
     // parse
-    var str = body
+    let str = body
     try {
       debug('parse body')
       str = typeof body !== 'string' && encoding !== null
@@ -182,8 +182,8 @@ function read (req, res, next, parse, debug, options) {
  * @private
  */
 function contentstream (req, debug, inflate) {
-  var encoding = (req.headers['content-encoding'] || 'identity').toLowerCase()
-  var length = req.headers['content-length']
+  const encoding = (req.headers['content-encoding'] || 'identity').toLowerCase()
+  const length = req.headers['content-length']
 
   debug('content-encoding "%s"', encoding)
 
@@ -199,7 +199,7 @@ function contentstream (req, debug, inflate) {
     return req
   }
 
-  var stream = createDecompressionStream(encoding, debug)
+  const stream = createDecompressionStream(encoding, debug)
   req.pipe(stream)
   return stream
 }

--- a/lib/types/json.js
+++ b/lib/types/json.js
@@ -12,9 +12,9 @@
  * @private
  */
 
-var debug = require('debug')('body-parser:json')
-var read = require('../read')
-var { normalizeOptions } = require('../utils')
+const debug = require('debug')('body-parser:json')
+const read = require('../read')
+const { normalizeOptions } = require('../utils')
 
 /**
  * Module exports.
@@ -33,10 +33,10 @@ module.exports = json
  *            %x0A /              ; Line feed or New line
  *            %x0D )              ; Carriage return
  */
-var FIRST_CHAR_REGEXP = /^[\x20\x09\x0a\x0d]*([^\x20\x09\x0a\x0d])/ // eslint-disable-line no-control-regex
+const FIRST_CHAR_REGEXP = /^[\x20\x09\x0a\x0d]*([^\x20\x09\x0a\x0d])/ // eslint-disable-line no-control-regex
 
-var JSON_SYNTAX_CHAR = '#'
-var JSON_SYNTAX_REGEXP = /#+/g
+const JSON_SYNTAX_CHAR = '#'
+const JSON_SYNTAX_REGEXP = /#+/g
 
 /**
  * Create a middleware to parse JSON bodies.
@@ -126,8 +126,8 @@ function createJsonParser (options) {
  * @private
  */
 function createStrictSyntaxError (str, char) {
-  var index = str.indexOf(char)
-  var partial = ''
+  const index = str.indexOf(char)
+  let partial = ''
 
   if (index !== -1) {
     partial = str.substring(0, index) + JSON_SYNTAX_CHAR.repeat(str.length - index)
@@ -153,7 +153,7 @@ function createStrictSyntaxError (str, char) {
  * @private
  */
 function firstchar (str) {
-  var match = FIRST_CHAR_REGEXP.exec(str)
+  const match = FIRST_CHAR_REGEXP.exec(str)
 
   return match
     ? match[1]
@@ -169,10 +169,10 @@ function firstchar (str) {
  * @private
  */
 function normalizeJsonSyntaxError (error, obj) {
-  var keys = Object.getOwnPropertyNames(error)
+  const keys = Object.getOwnPropertyNames(error)
 
-  for (var i = 0; i < keys.length; i++) {
-    var key = keys[i]
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i]
     if (key !== 'stack' && key !== 'message') {
       delete error[key]
     }

--- a/lib/types/raw.js
+++ b/lib/types/raw.js
@@ -10,9 +10,9 @@
  * Module dependencies.
  */
 
-var debug = require('debug')('body-parser:raw')
-var read = require('../read')
-var { normalizeOptions, passthrough } = require('../utils')
+const debug = require('debug')('body-parser:raw')
+const read = require('../read')
+const { normalizeOptions, passthrough } = require('../utils')
 
 /**
  * Module exports.

--- a/lib/types/text.js
+++ b/lib/types/text.js
@@ -10,9 +10,9 @@
  * Module dependencies.
  */
 
-var debug = require('debug')('body-parser:text')
-var read = require('../read')
-var { normalizeOptions, passthrough } = require('../utils')
+const debug = require('debug')('body-parser:text')
+const read = require('../read')
+const { normalizeOptions, passthrough } = require('../utils')
 
 /**
  * Module exports.

--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -12,11 +12,11 @@
  * @private
  */
 
-var createError = require('http-errors')
-var debug = require('debug')('body-parser:urlencoded')
-var read = require('../read')
-var qs = require('qs')
-var { normalizeOptions } = require('../utils')
+const createError = require('http-errors')
+const debug = require('debug')('body-parser:urlencoded')
+const read = require('../read')
+const qs = require('qs')
+const { normalizeOptions } = require('../utils')
 
 /**
  * Module exports.
@@ -60,13 +60,13 @@ function urlencoded (options) {
  * @private
  */
 function createQueryParser (options) {
-  var extended = Boolean(options?.extended)
-  var parameterLimit = options?.parameterLimit !== undefined
+  const extended = Boolean(options?.extended)
+  let parameterLimit = options?.parameterLimit !== undefined
     ? options?.parameterLimit
     : 1000
-  var charsetSentinel = options?.charsetSentinel
-  var interpretNumericEntities = options?.interpretNumericEntities
-  var depth = extended ? (options?.depth !== undefined ? options?.depth : 32) : 0
+  const charsetSentinel = options?.charsetSentinel
+  const interpretNumericEntities = options?.interpretNumericEntities
+  const depth = extended ? (options?.depth !== undefined ? options?.depth : 32) : 0
 
   if (isNaN(parameterLimit) || parameterLimit < 1) {
     throw new TypeError('option parameterLimit must be a positive number')
@@ -83,7 +83,7 @@ function createQueryParser (options) {
   return function parse (body, encoding) {
     if (!body.length) return {}
 
-    var paramCount = parameterCount(body, parameterLimit)
+    const paramCount = parameterCount(body, parameterLimit)
 
     if (paramCount === undefined) {
       debug('too many parameters')
@@ -92,7 +92,7 @@ function createQueryParser (options) {
       })
     }
 
-    var arrayLimit = extended ? Math.max(100, paramCount) : paramCount
+    const arrayLimit = extended ? Math.max(100, paramCount) : paramCount
 
     debug('parse ' + (extended ? 'extended ' : '') + 'urlencoding')
     try {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,9 +4,9 @@
  * Module dependencies.
  */
 
-var bytes = require('bytes')
-var contentType = require('content-type')
-var typeis = require('type-is')
+const bytes = require('bytes')
+const contentType = require('content-type')
+const typeis = require('type-is')
 
 /**
  * Module exports.
@@ -25,7 +25,7 @@ module.exports = {
  * @private
  */
 function getCharset (req) {
-  var header = req.headers['content-type']
+  const header = req.headers['content-type']
   if (!header) return undefined
   return contentType.parse(header).parameters.charset?.toLowerCase()
 }
@@ -57,13 +57,13 @@ function normalizeOptions (options, defaultType) {
     throw new TypeError('defaultType must be provided')
   }
 
-  var inflate = options?.inflate !== false
-  var limit = typeof options?.limit === 'undefined' || options?.limit === null
+  const inflate = options?.inflate !== false
+  const limit = typeof options?.limit === 'undefined' || options?.limit === null
     ? 102400 // 100kb default
     : bytes.parse(options.limit)
-  var type = options?.type || defaultType
-  var verify = options?.verify || false
-  var defaultCharset = options?.defaultCharset || 'utf-8'
+  const type = options?.type || defaultType
+  const verify = options?.verify || false
+  const defaultCharset = options?.defaultCharset || 'utf-8'
 
   if (limit === null) {
     throw new TypeError(`option limit "${String(options.limit)}" is invalid`)
@@ -74,7 +74,7 @@ function normalizeOptions (options, defaultType) {
   }
 
   // create the appropriate type checking function
-  var shouldParse = typeof type !== 'function'
+  const shouldParse = typeof type !== 'function'
     ? typeChecker(type)
     : type
 

--- a/test/body-parser.js
+++ b/test/body-parser.js
@@ -1,8 +1,8 @@
 'use strict'
 
-var assert = require('node:assert')
+const assert = require('node:assert')
 
-var bodyParser = require('..')
+const bodyParser = require('..')
 
 describe('bodyParser()', function () {
   it('should throw an error', function () {

--- a/test/json.js
+++ b/test/json.js
@@ -1,11 +1,11 @@
 'use strict'
 
-var assert = require('node:assert')
-var AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
-var http = require('node:http')
-var request = require('supertest')
+const assert = require('node:assert')
+const AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
+const http = require('node:http')
+const request = require('supertest')
 
-var bodyParser = require('..')
+const bodyParser = require('..')
 
 describe('bodyParser.json()', function () {
   it('should parse JSON', function (done) {
@@ -49,8 +49,8 @@ describe('bodyParser.json()', function () {
   })
 
   it('should 400 when invalid content-length', function (done) {
-    var jsonParser = bodyParser.json()
-    var server = createServer(function (req, res, next) {
+    const jsonParser = bodyParser.json()
+    const server = createServer(function (req, res, next) {
       req.headers['content-length'] = '20' // bad length
       jsonParser(req, res, next)
     })
@@ -63,8 +63,8 @@ describe('bodyParser.json()', function () {
   })
 
   it('should handle consumed request', function (done) {
-    var jsonParser = bodyParser.json()
-    var server = createServer(function (req, res, next) {
+    const jsonParser = bodyParser.json()
+    const server = createServer(function (req, res, next) {
       req.on('end', function () {
         jsonParser(req, res, next)
       })
@@ -79,8 +79,8 @@ describe('bodyParser.json()', function () {
   })
 
   it('should handle duplicated middleware', function (done) {
-    var jsonParser = bodyParser.json()
-    var server = createServer(function (req, res, next) {
+    const jsonParser = bodyParser.json()
+    const server = createServer(function (req, res, next) {
       jsonParser(req, res, function (err) {
         if (err) return next(err)
         jsonParser(req, res, next)
@@ -127,7 +127,7 @@ describe('bodyParser.json()', function () {
 
   describe('with limit option', function () {
     it('should 413 when over limit with Content-Length', function (done) {
-      var buf = Buffer.alloc(1024, '.')
+      const buf = Buffer.alloc(1024, '.')
       request(createServer({ limit: '1kb' }))
         .post('/')
         .set('Content-Type', 'application/json')
@@ -137,9 +137,9 @@ describe('bodyParser.json()', function () {
     })
 
     it('should 413 when over limit with chunked encoding', function (done) {
-      var buf = Buffer.alloc(1024, '.')
-      var server = createServer({ limit: '1kb' })
-      var test = request(server).post('/')
+      const buf = Buffer.alloc(1024, '.')
+      const server = createServer({ limit: '1kb' })
+      const test = request(server).post('/')
       test.set('Content-Type', 'application/json')
       test.set('Transfer-Encoding', 'chunked')
       test.write('{"str":')
@@ -148,8 +148,8 @@ describe('bodyParser.json()', function () {
     })
 
     it('should 413 when inflated body over limit', function (done) {
-      var server = createServer({ limit: '1kb' })
-      var test = request(server).post('/')
+      const server = createServer({ limit: '1kb' })
+      const test = request(server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/json')
       test.write(Buffer.from('1f8b080000000000000aab562a2e2952b252d21b05a360148c58a0540b0066f7ce1e0a040000', 'hex'))
@@ -157,7 +157,7 @@ describe('bodyParser.json()', function () {
     })
 
     it('should accept number of bytes', function (done) {
-      var buf = Buffer.alloc(1024, '.')
+      const buf = Buffer.alloc(1024, '.')
       request(createServer({ limit: 1024 }))
         .post('/')
         .set('Content-Type', 'application/json')
@@ -166,9 +166,9 @@ describe('bodyParser.json()', function () {
     })
 
     it('should not change when options altered', function (done) {
-      var buf = Buffer.alloc(1024, '.')
-      var options = { limit: '1kb' }
-      var server = createServer(options)
+      const buf = Buffer.alloc(1024, '.')
+      const options = { limit: '1kb' }
+      const server = createServer(options)
 
       options.limit = '100kb'
 
@@ -180,9 +180,9 @@ describe('bodyParser.json()', function () {
     })
 
     it('should not hang response', function (done) {
-      var buf = Buffer.alloc(10240, '.')
-      var server = createServer({ limit: '8kb' })
-      var test = request(server).post('/')
+      const buf = Buffer.alloc(10240, '.')
+      const server = createServer({ limit: '8kb' })
+      const test = request(server).post('/')
       test.set('Content-Type', 'application/json')
       test.write(buf)
       test.write(buf)
@@ -191,8 +191,8 @@ describe('bodyParser.json()', function () {
     })
 
     it('should not error when inflating', function (done) {
-      var server = createServer({ limit: '1kb' })
-      var test = request(server).post('/')
+      const server = createServer({ limit: '1kb' })
+      const test = request(server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/json')
       test.write(Buffer.from('1f8b080000000000000aab562a2e2952b252d21b05a360148c58a0540b0066f7ce1e0a0400', 'hex'))
@@ -207,7 +207,7 @@ describe('bodyParser.json()', function () {
       })
 
       it('should not accept content-encoding', function (done) {
-        var test = request(this.server).post('/')
+        const test = request(this.server).post('/')
         test.set('Content-Encoding', 'gzip')
         test.set('Content-Type', 'application/json')
         test.write(Buffer.from('1f8b080000000000000bab56ca4bcc4d55b2527ab16e97522d00515be1cc0e000000', 'hex'))
@@ -221,7 +221,7 @@ describe('bodyParser.json()', function () {
       })
 
       it('should accept content-encoding', function (done) {
-        var test = request(this.server).post('/')
+        const test = request(this.server).post('/')
         test.set('Content-Encoding', 'gzip')
         test.set('Content-Type', 'application/json')
         test.write(Buffer.from('1f8b080000000000000bab56ca4bcc4d55b2527ab16e97522d00515be1cc0e000000', 'hex'))
@@ -374,7 +374,7 @@ describe('bodyParser.json()', function () {
 
     describe('when a function', function () {
       it('should parse when truthy value returned', function (done) {
-        var server = createServer({ type: accept })
+        const server = createServer({ type: accept })
 
         function accept (req) {
           return req.headers['content-type'] === 'application/vnd.api+json'
@@ -388,19 +388,19 @@ describe('bodyParser.json()', function () {
       })
 
       it('should work without content-type', function (done) {
-        var server = createServer({ type: accept })
+        const server = createServer({ type: accept })
 
         function accept (req) {
           return true
         }
 
-        var test = request(server).post('/')
+        const test = request(server).post('/')
         test.write('{"user":"tobi"}')
         test.expect(200, '{"user":"tobi"}', done)
       })
 
       it('should not invoke without a body', function (done) {
-        var server = createServer({ type: accept })
+        const server = createServer({ type: accept })
 
         function accept (req) {
           throw new Error('oops!')
@@ -420,7 +420,7 @@ describe('bodyParser.json()', function () {
     })
 
     it('should error from verify', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           if (buf[0] === 0x5b) throw new Error('no arrays')
         }
@@ -434,10 +434,10 @@ describe('bodyParser.json()', function () {
     })
 
     it('should allow custom codes', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           if (buf[0] !== 0x5b) return
-          var err = new Error('no arrays')
+          const err = new Error('no arrays')
           err.status = 400
           throw err
         }
@@ -451,10 +451,10 @@ describe('bodyParser.json()', function () {
     })
 
     it('should allow custom type', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           if (buf[0] !== 0x5b) return
-          var err = new Error('no arrays')
+          const err = new Error('no arrays')
           err.type = 'foo.bar'
           throw err
         }
@@ -468,7 +468,7 @@ describe('bodyParser.json()', function () {
     })
 
     it('should include original body on error object', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           if (buf[0] === 0x5b) throw new Error('no arrays')
         }
@@ -483,7 +483,7 @@ describe('bodyParser.json()', function () {
     })
 
     it('should allow pass-through', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           if (buf[0] === 0x5b) throw new Error('no arrays')
         }
@@ -497,26 +497,26 @@ describe('bodyParser.json()', function () {
     })
 
     it('should work with different charsets', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           if (buf[0] === 0x5b) throw new Error('no arrays')
         }
       })
 
-      var test = request(server).post('/')
+      const test = request(server).post('/')
       test.set('Content-Type', 'application/json; charset=utf-16')
       test.write(Buffer.from('feff007b0022006e0061006d00650022003a00228bba0022007d', 'hex'))
       test.expect(200, '{"name":"论"}', done)
     })
 
     it('should 415 on unknown charset prior to verify', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           throw new Error('unexpected verify call')
         }
       })
 
-      var test = request(server).post('/')
+      const test = request(server).post('/')
       test.set('Content-Type', 'application/json; charset=x-bogus')
       test.write(Buffer.from('00000000', 'hex'))
       test.expect(415, '[charset.unsupported] unsupported charset "X-BOGUS"', done)
@@ -525,15 +525,15 @@ describe('bodyParser.json()', function () {
 
   describe('async local storage', function () {
     before(function () {
-      var jsonParser = bodyParser.json()
-      var store = { foo: 'bar' }
+      const jsonParser = bodyParser.json()
+      const store = { foo: 'bar' }
 
       this.server = createServer(function (req, res, next) {
-        var asyncLocalStorage = new AsyncLocalStorage()
+        const asyncLocalStorage = new AsyncLocalStorage()
 
         asyncLocalStorage.run(store, function () {
           jsonParser(req, res, function (err) {
-            var local = asyncLocalStorage.getStore()
+            const local = asyncLocalStorage.getStore()
 
             if (local) {
               res.setHeader('x-store-foo', String(local.foo))
@@ -568,7 +568,7 @@ describe('bodyParser.json()', function () {
     })
 
     it('should presist store when inflated', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/json')
       test.write(Buffer.from('1f8b080000000000000bab56ca4bcc4d55b2527ab16e97522d00515be1cc0e000000', 'hex'))
@@ -579,7 +579,7 @@ describe('bodyParser.json()', function () {
     })
 
     it('should presist store when inflate error', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/json')
       test.write(Buffer.from('1f8b080000000000000bab56cc4d55b2527ab16e97522d00515be1cc0e000000', 'hex'))
@@ -615,28 +615,28 @@ describe('bodyParser.json()', function () {
     })
 
     it('should parse utf-8', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'application/json; charset=utf-8')
       test.write(Buffer.from('7b226e616d65223a22e8aeba227d', 'hex'))
       test.expect(200, '{"name":"论"}', done)
     })
 
     it('should parse utf-16', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'application/json; charset=utf-16')
       test.write(Buffer.from('feff007b0022006e0061006d00650022003a00228bba0022007d', 'hex'))
       test.expect(200, '{"name":"论"}', done)
     })
 
     it('should parse utf-32', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'application/json; charset=utf-32')
       test.write(Buffer.from('fffe00007b000000220000006e000000610000006d00000065000000220000003a00000022000000ba8b0000220000007d000000', 'hex'))
       test.expect(200, '{"name":"论"}', done)
     })
 
     it('should parse when content-length != char length', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'application/json; charset=utf-8')
       test.set('Content-Length', '13')
       test.write(Buffer.from('7b2274657374223a22c3a5227d', 'hex'))
@@ -644,14 +644,14 @@ describe('bodyParser.json()', function () {
     })
 
     it('should default to utf-8', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'application/json')
       test.write(Buffer.from('7b226e616d65223a22e8aeba227d', 'hex'))
       test.expect(200, '{"name":"论"}', done)
     })
 
     it('should fail on unknown charset', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'application/json; charset=koi8-r')
       test.write(Buffer.from('7b226e616d65223a22cec5d4227d', 'hex'))
       test.expect(415, '[charset.unsupported] unsupported charset "KOI8-R"', done)
@@ -664,14 +664,14 @@ describe('bodyParser.json()', function () {
     })
 
     it('should parse without encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'application/json')
       test.write(Buffer.from('7b226e616d65223a22e8aeba227d', 'hex'))
       test.expect(200, '{"name":"论"}', done)
     })
 
     it('should support identity encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'identity')
       test.set('Content-Type', 'application/json')
       test.write(Buffer.from('7b226e616d65223a22e8aeba227d', 'hex'))
@@ -679,7 +679,7 @@ describe('bodyParser.json()', function () {
     })
 
     it('should support gzip encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/json')
       test.write(Buffer.from('1f8b080000000000000bab56ca4bcc4d55b2527ab16e97522d00515be1cc0e000000', 'hex'))
@@ -687,7 +687,7 @@ describe('bodyParser.json()', function () {
     })
 
     it('should support deflate encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'deflate')
       test.set('Content-Type', 'application/json')
       test.write(Buffer.from('789cab56ca4bcc4d55b2527ab16e97522d00274505ac', 'hex'))
@@ -695,7 +695,7 @@ describe('bodyParser.json()', function () {
     })
 
     it('should support brotli encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'br')
       test.set('Content-Type', 'application/json')
       test.write(Buffer.from('8b06807b226e616d65223a22e8aeba227d03', 'hex'))
@@ -703,7 +703,7 @@ describe('bodyParser.json()', function () {
     })
 
     it('should be case-insensitive', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'GZIP')
       test.set('Content-Type', 'application/json')
       test.write(Buffer.from('1f8b080000000000000bab56ca4bcc4d55b2527ab16e97522d00515be1cc0e000000', 'hex'))
@@ -711,7 +711,7 @@ describe('bodyParser.json()', function () {
     })
 
     it('should 415 on unknown encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'nulls')
       test.set('Content-Type', 'application/json')
       test.write(Buffer.from('000000000000', 'hex'))
@@ -719,7 +719,7 @@ describe('bodyParser.json()', function () {
     })
 
     it('should 400 on malformed encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/json')
       test.write(Buffer.from('1f8b080000000000000bab56cc4d55b2527ab16e97522d00515be1cc0e000000', 'hex'))
@@ -728,7 +728,7 @@ describe('bodyParser.json()', function () {
 
     it('should 413 when inflated value exceeds limit', function (done) {
       // gzip'd data exceeds 1kb, but deflated below 1kb
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/json')
       test.write(Buffer.from('1f8b080000000000000bedc1010d000000c2a0f74f6d0f071400000000000000', 'hex'))
@@ -740,7 +740,7 @@ describe('bodyParser.json()', function () {
 })
 
 function createServer (opts) {
-  var _bodyParser = typeof opts !== 'function'
+  const _bodyParser = typeof opts !== 'function'
     ? bodyParser.json(opts)
     : opts
 

--- a/test/raw.js
+++ b/test/raw.js
@@ -1,11 +1,11 @@
 'use strict'
 
-var assert = require('node:assert')
-var AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
-var http = require('node:http')
-var request = require('supertest')
+const assert = require('node:assert')
+const AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
+const http = require('node:http')
+const request = require('supertest')
 
-var bodyParser = require('..')
+const bodyParser = require('..')
 
 describe('bodyParser.raw()', function () {
   before(function () {
@@ -21,8 +21,8 @@ describe('bodyParser.raw()', function () {
   })
 
   it('should 400 when invalid content-length', function (done) {
-    var rawParser = bodyParser.raw()
-    var server = createServer(function (req, res, next) {
+    const rawParser = bodyParser.raw()
+    const server = createServer(function (req, res, next) {
       req.headers['content-length'] = '20' // bad length
       rawParser(req, res, next)
     })
@@ -52,8 +52,8 @@ describe('bodyParser.raw()', function () {
   })
 
   it('should handle consumed stream', function (done) {
-    var rawParser = bodyParser.raw()
-    var server = createServer(function (req, res, next) {
+    const rawParser = bodyParser.raw()
+    const server = createServer(function (req, res, next) {
       req.on('end', function () {
         rawParser(req, res, next)
       })
@@ -68,8 +68,8 @@ describe('bodyParser.raw()', function () {
   })
 
   it('should handle duplicated middleware', function (done) {
-    var rawParser = bodyParser.raw()
-    var server = createServer(function (req, res, next) {
+    const rawParser = bodyParser.raw()
+    const server = createServer(function (req, res, next) {
       rawParser(req, res, function (err) {
         if (err) return next(err)
         rawParser(req, res, next)
@@ -85,9 +85,9 @@ describe('bodyParser.raw()', function () {
 
   describe('with limit option', function () {
     it('should 413 when over limit with Content-Length', function (done) {
-      var buf = Buffer.alloc(1028, '.')
-      var server = createServer({ limit: '1kb' })
-      var test = request(server).post('/')
+      const buf = Buffer.alloc(1028, '.')
+      const server = createServer({ limit: '1kb' })
+      const test = request(server).post('/')
       test.set('Content-Type', 'application/octet-stream')
       test.set('Content-Length', '1028')
       test.write(buf)
@@ -95,9 +95,9 @@ describe('bodyParser.raw()', function () {
     })
 
     it('should 413 when over limit with chunked encoding', function (done) {
-      var buf = Buffer.alloc(1028, '.')
-      var server = createServer({ limit: '1kb' })
-      var test = request(server).post('/')
+      const buf = Buffer.alloc(1028, '.')
+      const server = createServer({ limit: '1kb' })
+      const test = request(server).post('/')
       test.set('Content-Type', 'application/octet-stream')
       test.set('Transfer-Encoding', 'chunked')
       test.write(buf)
@@ -105,8 +105,8 @@ describe('bodyParser.raw()', function () {
     })
 
     it('should 413 when inflated body over limit', function (done) {
-      var server = createServer({ limit: '1kb' })
-      var test = request(server).post('/')
+      const server = createServer({ limit: '1kb' })
+      const test = request(server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('1f8b080000000000000ad3d31b05a360148c64000087e5a14704040000', 'hex'))
@@ -114,31 +114,31 @@ describe('bodyParser.raw()', function () {
     })
 
     it('should accept number of bytes', function (done) {
-      var buf = Buffer.alloc(1028, '.')
-      var server = createServer({ limit: 1024 })
-      var test = request(server).post('/')
+      const buf = Buffer.alloc(1028, '.')
+      const server = createServer({ limit: 1024 })
+      const test = request(server).post('/')
       test.set('Content-Type', 'application/octet-stream')
       test.write(buf)
       test.expect(413, done)
     })
 
     it('should not change when options altered', function (done) {
-      var buf = Buffer.alloc(1028, '.')
-      var options = { limit: '1kb' }
-      var server = createServer(options)
+      const buf = Buffer.alloc(1028, '.')
+      const options = { limit: '1kb' }
+      const server = createServer(options)
 
       options.limit = '100kb'
 
-      var test = request(server).post('/')
+      const test = request(server).post('/')
       test.set('Content-Type', 'application/octet-stream')
       test.write(buf)
       test.expect(413, done)
     })
 
     it('should not hang response', function (done) {
-      var buf = Buffer.alloc(10240, '.')
-      var server = createServer({ limit: '8kb' })
-      var test = request(server).post('/')
+      const buf = Buffer.alloc(10240, '.')
+      const server = createServer({ limit: '8kb' })
+      const test = request(server).post('/')
       test.set('Content-Type', 'application/octet-stream')
       test.write(buf)
       test.write(buf)
@@ -147,8 +147,8 @@ describe('bodyParser.raw()', function () {
     })
 
     it('should not error when inflating', function (done) {
-      var server = createServer({ limit: '1kb' })
-      var test = request(server).post('/')
+      const server = createServer({ limit: '1kb' })
+      const test = request(server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('1f8b080000000000000ad3d31b05a360148c64000087e5a147040400', 'hex'))
@@ -163,7 +163,7 @@ describe('bodyParser.raw()', function () {
       })
 
       it('should not accept content-encoding', function (done) {
-        var test = request(this.server).post('/')
+        const test = request(this.server).post('/')
         test.set('Content-Encoding', 'gzip')
         test.set('Content-Type', 'application/octet-stream')
         test.write(Buffer.from('1f8b080000000000000bcb4bcc4db57db16e170099a4bad608000000', 'hex'))
@@ -177,7 +177,7 @@ describe('bodyParser.raw()', function () {
       })
 
       it('should accept content-encoding', function (done) {
-        var test = request(this.server).post('/')
+        const test = request(this.server).post('/')
         test.set('Content-Encoding', 'gzip')
         test.set('Content-Type', 'application/octet-stream')
         test.write(Buffer.from('1f8b080000000000000bcb4bcc4db57db16e170099a4bad608000000', 'hex'))
@@ -193,14 +193,14 @@ describe('bodyParser.raw()', function () {
       })
 
       it('should parse for custom type', function (done) {
-        var test = request(this.server).post('/')
+        const test = request(this.server).post('/')
         test.set('Content-Type', 'application/vnd+octets')
         test.write(Buffer.from('000102', 'hex'))
         test.expect(200, 'buf:000102', done)
       })
 
       it('should ignore standard type', function (done) {
-        var test = request(this.server).post('/')
+        const test = request(this.server).post('/')
         test.set('Content-Type', 'application/octet-stream')
         test.write(Buffer.from('000102', 'hex'))
         test.expect(200, 'undefined', done)
@@ -215,21 +215,21 @@ describe('bodyParser.raw()', function () {
       })
 
       it('should parse "application/octet-stream"', function (done) {
-        var test = request(this.server).post('/')
+        const test = request(this.server).post('/')
         test.set('Content-Type', 'application/octet-stream')
         test.write(Buffer.from('000102', 'hex'))
         test.expect(200, 'buf:000102', done)
       })
 
       it('should parse "application/vnd+octets"', function (done) {
-        var test = request(this.server).post('/')
+        const test = request(this.server).post('/')
         test.set('Content-Type', 'application/vnd+octets')
         test.write(Buffer.from('000102', 'hex'))
         test.expect(200, 'buf:000102', done)
       })
 
       it('should ignore "application/x-foo"', function (done) {
-        var test = request(this.server).post('/')
+        const test = request(this.server).post('/')
         test.set('Content-Type', 'application/x-foo')
         test.write(Buffer.from('000102', 'hex'))
         test.expect(200, 'undefined', done)
@@ -238,32 +238,32 @@ describe('bodyParser.raw()', function () {
 
     describe('when a function', function () {
       it('should parse when truthy value returned', function (done) {
-        var server = createServer({ type: accept })
+        const server = createServer({ type: accept })
 
         function accept (req) {
           return req.headers['content-type'] === 'application/vnd.octet'
         }
 
-        var test = request(server).post('/')
+        const test = request(server).post('/')
         test.set('Content-Type', 'application/vnd.octet')
         test.write(Buffer.from('000102', 'hex'))
         test.expect(200, 'buf:000102', done)
       })
 
       it('should work without content-type', function (done) {
-        var server = createServer({ type: accept })
+        const server = createServer({ type: accept })
 
         function accept (req) {
           return true
         }
 
-        var test = request(server).post('/')
+        const test = request(server).post('/')
         test.write(Buffer.from('000102', 'hex'))
         test.expect(200, 'buf:000102', done)
       })
 
       it('should not invoke without a body', function (done) {
-        var server = createServer({ type: accept })
+        const server = createServer({ type: accept })
 
         function accept (req) {
           throw new Error('oops!')
@@ -283,42 +283,42 @@ describe('bodyParser.raw()', function () {
     })
 
     it('should error from verify', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           if (buf[0] === 0x00) throw new Error('no leading null')
         }
       })
 
-      var test = request(server).post('/')
+      const test = request(server).post('/')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('000102', 'hex'))
       test.expect(403, '[entity.verify.failed] no leading null', done)
     })
 
     it('should allow custom codes', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           if (buf[0] !== 0x00) return
-          var err = new Error('no leading null')
+          const err = new Error('no leading null')
           err.status = 400
           throw err
         }
       })
 
-      var test = request(server).post('/')
+      const test = request(server).post('/')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('000102', 'hex'))
       test.expect(400, '[entity.verify.failed] no leading null', done)
     })
 
     it('should allow pass-through', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           if (buf[0] === 0x00) throw new Error('no leading null')
         }
       })
 
-      var test = request(server).post('/')
+      const test = request(server).post('/')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('0102', 'hex'))
       test.expect(200, 'buf:0102', done)
@@ -327,15 +327,15 @@ describe('bodyParser.raw()', function () {
 
   describe('async local storage', function () {
     before(function () {
-      var rawParser = bodyParser.raw()
-      var store = { foo: 'bar' }
+      const rawParser = bodyParser.raw()
+      const store = { foo: 'bar' }
 
       this.server = createServer(function (req, res, next) {
-        var asyncLocalStorage = new AsyncLocalStorage()
+        const asyncLocalStorage = new AsyncLocalStorage()
 
         asyncLocalStorage.run(store, function () {
           rawParser(req, res, function (err) {
-            var local = asyncLocalStorage.getStore()
+            const local = asyncLocalStorage.getStore()
 
             if (local) {
               res.setHeader('x-store-foo', String(local.foo))
@@ -370,7 +370,7 @@ describe('bodyParser.raw()', function () {
     })
 
     it('should presist store when inflated', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('1f8b080000000000000bcb4bcc4db57db16e170099a4bad608000000', 'hex'))
@@ -381,7 +381,7 @@ describe('bodyParser.raw()', function () {
     })
 
     it('should presist store when inflate error', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('1f8b080000000000000bcb4bcc4db57db16e170099a4bad6080000', 'hex'))
@@ -407,7 +407,7 @@ describe('bodyParser.raw()', function () {
     })
 
     it('should ignore charset', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'application/octet-stream; charset=utf-8')
       test.write(Buffer.from('6e616d6520697320e8aeba', 'hex'))
       test.expect(200, 'buf:6e616d6520697320e8aeba', done)
@@ -420,14 +420,14 @@ describe('bodyParser.raw()', function () {
     })
 
     it('should parse without encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('6e616d653de8aeba', 'hex'))
       test.expect(200, 'buf:6e616d653de8aeba', done)
     })
 
     it('should support identity encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'identity')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('6e616d653de8aeba', 'hex'))
@@ -435,7 +435,7 @@ describe('bodyParser.raw()', function () {
     })
 
     it('should support gzip encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('1f8b080000000000000bcb4bcc4db57db16e170099a4bad608000000', 'hex'))
@@ -443,7 +443,7 @@ describe('bodyParser.raw()', function () {
     })
 
     it('should support deflate encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'deflate')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('789ccb4bcc4db57db16e17001068042f', 'hex'))
@@ -451,7 +451,7 @@ describe('bodyParser.raw()', function () {
     })
 
     it('should support brotli encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'br')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('8b03806e616d653de8aeba03', 'hex'))
@@ -459,7 +459,7 @@ describe('bodyParser.raw()', function () {
     })
 
     it('should be case-insensitive', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'GZIP')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('1f8b080000000000000bcb4bcc4db57db16e170099a4bad608000000', 'hex'))
@@ -467,7 +467,7 @@ describe('bodyParser.raw()', function () {
     })
 
     it('should 415 on unknown encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'nulls')
       test.set('Content-Type', 'application/octet-stream')
       test.write(Buffer.from('000000000000', 'hex'))
@@ -477,7 +477,7 @@ describe('bodyParser.raw()', function () {
 })
 
 function createServer (opts) {
-  var _bodyParser = typeof opts !== 'function'
+  const _bodyParser = typeof opts !== 'function'
     ? bodyParser.raw(opts)
     : opts
 

--- a/test/text.js
+++ b/test/text.js
@@ -1,11 +1,11 @@
 'use strict'
 
-var assert = require('node:assert')
-var AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
-var http = require('node:http')
-var request = require('supertest')
+const assert = require('node:assert')
+const AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
+const http = require('node:http')
+const request = require('supertest')
 
-var bodyParser = require('..')
+const bodyParser = require('..')
 
 describe('bodyParser.text()', function () {
   before(function () {
@@ -21,8 +21,8 @@ describe('bodyParser.text()', function () {
   })
 
   it('should 400 when invalid content-length', function (done) {
-    var textParser = bodyParser.text()
-    var server = createServer(function (req, res, next) {
+    const textParser = bodyParser.text()
+    const server = createServer(function (req, res, next) {
       req.headers['content-length'] = '20' // bad length
       textParser(req, res, next)
     })
@@ -52,8 +52,8 @@ describe('bodyParser.text()', function () {
   })
 
   it('should handle consumed stream', function (done) {
-    var textParser = bodyParser.text()
-    var server = createServer(function (req, res, next) {
+    const textParser = bodyParser.text()
+    const server = createServer(function (req, res, next) {
       req.on('end', function () {
         textParser(req, res, next)
       })
@@ -68,8 +68,8 @@ describe('bodyParser.text()', function () {
   })
 
   it('should handle duplicated middleware', function (done) {
-    var textParser = bodyParser.text()
-    var server = createServer(function (req, res, next) {
+    const textParser = bodyParser.text()
+    const server = createServer(function (req, res, next) {
       textParser(req, res, function (err) {
         if (err) return next(err)
         textParser(req, res, next)
@@ -85,16 +85,16 @@ describe('bodyParser.text()', function () {
 
   describe('with defaultCharset option', function () {
     it('should change default charset', function (done) {
-      var server = createServer({ defaultCharset: 'koi8-r' })
-      var test = request(server).post('/')
+      const server = createServer({ defaultCharset: 'koi8-r' })
+      const test = request(server).post('/')
       test.set('Content-Type', 'text/plain')
       test.write(Buffer.from('6e616d6520697320cec5d4', 'hex'))
       test.expect(200, '"name is нет"', done)
     })
 
     it('should honor content-type charset', function (done) {
-      var server = createServer({ defaultCharset: 'koi8-r' })
-      var test = request(server).post('/')
+      const server = createServer({ defaultCharset: 'koi8-r' })
+      const test = request(server).post('/')
       test.set('Content-Type', 'text/plain; charset=utf-8')
       test.write(Buffer.from('6e616d6520697320e8aeba', 'hex'))
       test.expect(200, '"name is 论"', done)
@@ -103,7 +103,7 @@ describe('bodyParser.text()', function () {
 
   describe('with limit option', function () {
     it('should 413 when over limit with Content-Length', function (done) {
-      var buf = Buffer.alloc(1028, '.')
+      const buf = Buffer.alloc(1028, '.')
       request(createServer({ limit: '1kb' }))
         .post('/')
         .set('Content-Type', 'text/plain')
@@ -113,9 +113,9 @@ describe('bodyParser.text()', function () {
     })
 
     it('should 413 when over limit with chunked encoding', function (done) {
-      var buf = Buffer.alloc(1028, '.')
-      var server = createServer({ limit: '1kb' })
-      var test = request(server).post('/')
+      const buf = Buffer.alloc(1028, '.')
+      const server = createServer({ limit: '1kb' })
+      const test = request(server).post('/')
       test.set('Content-Type', 'text/plain')
       test.set('Transfer-Encoding', 'chunked')
       test.write(buf.toString())
@@ -123,8 +123,8 @@ describe('bodyParser.text()', function () {
     })
 
     it('should 413 when inflated body over limit', function (done) {
-      var server = createServer({ limit: '1kb' })
-      var test = request(server).post('/')
+      const server = createServer({ limit: '1kb' })
+      const test = request(server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'text/plain')
       test.write(Buffer.from('1f8b080000000000000ad3d31b05a360148c64000087e5a14704040000', 'hex'))
@@ -132,7 +132,7 @@ describe('bodyParser.text()', function () {
     })
 
     it('should accept number of bytes', function (done) {
-      var buf = Buffer.alloc(1028, '.')
+      const buf = Buffer.alloc(1028, '.')
       request(createServer({ limit: 1024 }))
         .post('/')
         .set('Content-Type', 'text/plain')
@@ -141,9 +141,9 @@ describe('bodyParser.text()', function () {
     })
 
     it('should not change when options altered', function (done) {
-      var buf = Buffer.alloc(1028, '.')
-      var options = { limit: '1kb' }
-      var server = createServer(options)
+      const buf = Buffer.alloc(1028, '.')
+      const options = { limit: '1kb' }
+      const server = createServer(options)
 
       options.limit = '100kb'
 
@@ -155,9 +155,9 @@ describe('bodyParser.text()', function () {
     })
 
     it('should not hang response', function (done) {
-      var buf = Buffer.alloc(10240, '.')
-      var server = createServer({ limit: '8kb' })
-      var test = request(server).post('/')
+      const buf = Buffer.alloc(10240, '.')
+      const server = createServer({ limit: '8kb' })
+      const test = request(server).post('/')
       test.set('Content-Type', 'text/plain')
       test.write(buf)
       test.write(buf)
@@ -166,8 +166,8 @@ describe('bodyParser.text()', function () {
     })
 
     it('should not error when inflating', function (done) {
-      var server = createServer({ limit: '1kb' })
-      var test = request(server).post('/')
+      const server = createServer({ limit: '1kb' })
+      const test = request(server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'text/plain')
       test.write(Buffer.from('1f8b080000000000000ad3d31b05a360148c64000087e5a1470404', 'hex'))
@@ -184,7 +184,7 @@ describe('bodyParser.text()', function () {
       })
 
       it('should not accept content-encoding', function (done) {
-        var test = request(this.server).post('/')
+        const test = request(this.server).post('/')
         test.set('Content-Encoding', 'gzip')
         test.set('Content-Type', 'text/plain')
         test.write(Buffer.from('1f8b080000000000000bcb4bcc4d55c82c5678b16e170072b3e0200b000000', 'hex'))
@@ -198,7 +198,7 @@ describe('bodyParser.text()', function () {
       })
 
       it('should accept content-encoding', function (done) {
-        var test = request(this.server).post('/')
+        const test = request(this.server).post('/')
         test.set('Content-Encoding', 'gzip')
         test.set('Content-Type', 'text/plain')
         test.write(Buffer.from('1f8b080000000000000bcb4bcc4d55c82c5678b16e170072b3e0200b000000', 'hex'))
@@ -262,7 +262,7 @@ describe('bodyParser.text()', function () {
 
     describe('when a function', function () {
       it('should parse when truthy value returned', function (done) {
-        var server = createServer({ type: accept })
+        const server = createServer({ type: accept })
 
         function accept (req) {
           return req.headers['content-type'] === 'text/vnd.something'
@@ -276,19 +276,19 @@ describe('bodyParser.text()', function () {
       })
 
       it('should work without content-type', function (done) {
-        var server = createServer({ type: accept })
+        const server = createServer({ type: accept })
 
         function accept (req) {
           return true
         }
 
-        var test = request(server).post('/')
+        const test = request(server).post('/')
         test.write('user is tobi')
         test.expect(200, '"user is tobi"', done)
       })
 
       it('should not invoke without a body', function (done) {
-        var server = createServer({ type: accept })
+        const server = createServer({ type: accept })
 
         function accept (req) {
           throw new Error('oops!')
@@ -308,7 +308,7 @@ describe('bodyParser.text()', function () {
     })
 
     it('should error from verify', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           if (buf[0] === 0x20) throw new Error('no leading space')
         }
@@ -322,10 +322,10 @@ describe('bodyParser.text()', function () {
     })
 
     it('should allow custom codes', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           if (buf[0] !== 0x20) return
-          var err = new Error('no leading space')
+          const err = new Error('no leading space')
           err.status = 400
           throw err
         }
@@ -339,7 +339,7 @@ describe('bodyParser.text()', function () {
     })
 
     it('should allow pass-through', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           if (buf[0] === 0x20) throw new Error('no leading space')
         }
@@ -353,13 +353,13 @@ describe('bodyParser.text()', function () {
     })
 
     it('should 415 on unknown charset prior to verify', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           throw new Error('unexpected verify call')
         }
       })
 
-      var test = request(server).post('/')
+      const test = request(server).post('/')
       test.set('Content-Type', 'text/plain; charset=x-bogus')
       test.write(Buffer.from('00000000', 'hex'))
       test.expect(415, '[charset.unsupported] unsupported charset "X-BOGUS"', done)
@@ -368,15 +368,15 @@ describe('bodyParser.text()', function () {
 
   describe('async local storage', function () {
     before(function () {
-      var textParser = bodyParser.text()
-      var store = { foo: 'bar' }
+      const textParser = bodyParser.text()
+      const store = { foo: 'bar' }
 
       this.server = createServer(function (req, res, next) {
-        var asyncLocalStorage = new AsyncLocalStorage()
+        const asyncLocalStorage = new AsyncLocalStorage()
 
         asyncLocalStorage.run(store, function () {
           textParser(req, res, function (err) {
-            var local = asyncLocalStorage.getStore()
+            const local = asyncLocalStorage.getStore()
 
             if (local) {
               res.setHeader('x-store-foo', String(local.foo))
@@ -411,7 +411,7 @@ describe('bodyParser.text()', function () {
     })
 
     it('should presist store when inflated', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'text/plain')
       test.write(Buffer.from('1f8b080000000000000bcb4bcc4d55c82c5678b16e170072b3e0200b000000', 'hex'))
@@ -422,7 +422,7 @@ describe('bodyParser.text()', function () {
     })
 
     it('should presist store when inflate error', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'text/plain')
       test.write(Buffer.from('1f8b080000000000000bcb4bcc4d55c82c5678b16e170072b3e0200b0000', 'hex'))
@@ -448,21 +448,21 @@ describe('bodyParser.text()', function () {
     })
 
     it('should parse utf-8', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'text/plain; charset=utf-8')
       test.write(Buffer.from('6e616d6520697320e8aeba', 'hex'))
       test.expect(200, '"name is 论"', done)
     })
 
     it('should parse codepage charsets', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'text/plain; charset=koi8-r')
       test.write(Buffer.from('6e616d6520697320cec5d4', 'hex'))
       test.expect(200, '"name is нет"', done)
     })
 
     it('should parse when content-length != char length', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'text/plain; charset=utf-8')
       test.set('Content-Length', '11')
       test.write(Buffer.from('6e616d6520697320e8aeba', 'hex'))
@@ -470,14 +470,14 @@ describe('bodyParser.text()', function () {
     })
 
     it('should default to utf-8', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'text/plain')
       test.write(Buffer.from('6e616d6520697320e8aeba', 'hex'))
       test.expect(200, '"name is 论"', done)
     })
 
     it('should 415 on unknown charset', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'text/plain; charset=x-bogus')
       test.write(Buffer.from('00000000', 'hex'))
       test.expect(415, '[charset.unsupported] unsupported charset "X-BOGUS"', done)
@@ -490,14 +490,14 @@ describe('bodyParser.text()', function () {
     })
 
     it('should parse without encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'text/plain')
       test.write(Buffer.from('6e616d6520697320e8aeba', 'hex'))
       test.expect(200, '"name is 论"', done)
     })
 
     it('should support identity encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'identity')
       test.set('Content-Type', 'text/plain')
       test.write(Buffer.from('6e616d6520697320e8aeba', 'hex'))
@@ -505,7 +505,7 @@ describe('bodyParser.text()', function () {
     })
 
     it('should support gzip encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'text/plain')
       test.write(Buffer.from('1f8b080000000000000bcb4bcc4d55c82c5678b16e170072b3e0200b000000', 'hex'))
@@ -513,7 +513,7 @@ describe('bodyParser.text()', function () {
     })
 
     it('should support deflate encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'deflate')
       test.set('Content-Type', 'text/plain')
       test.write(Buffer.from('789ccb4bcc4d55c82c5678b16e17001a6f050e', 'hex'))
@@ -521,7 +521,7 @@ describe('bodyParser.text()', function () {
     })
 
     it('should support brotli encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'br')
       test.set('Content-Type', 'text/plain')
       test.write(Buffer.from('0b05806e616d6520697320e8aeba03', 'hex'))
@@ -529,7 +529,7 @@ describe('bodyParser.text()', function () {
     })
 
     it('should be case-insensitive', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'GZIP')
       test.set('Content-Type', 'text/plain')
       test.write(Buffer.from('1f8b080000000000000bcb4bcc4d55c82c5678b16e170072b3e0200b000000', 'hex'))
@@ -537,7 +537,7 @@ describe('bodyParser.text()', function () {
     })
 
     it('should 415 on unknown encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'nulls')
       test.set('Content-Type', 'text/plain')
       test.write(Buffer.from('000000000000', 'hex'))
@@ -547,7 +547,7 @@ describe('bodyParser.text()', function () {
 })
 
 function createServer (opts) {
-  var _bodyParser = typeof opts !== 'function'
+  const _bodyParser = typeof opts !== 'function'
     ? bodyParser.text(opts)
     : opts
 

--- a/test/urlencoded.js
+++ b/test/urlencoded.js
@@ -1,11 +1,11 @@
 'use strict'
 
-var assert = require('node:assert')
-var AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
-var http = require('node:http')
-var request = require('supertest')
+const assert = require('node:assert')
+const AsyncLocalStorage = require('node:async_hooks').AsyncLocalStorage
+const http = require('node:http')
+const request = require('supertest')
 
-var bodyParser = require('..')
+const bodyParser = require('..')
 
 describe('bodyParser.urlencoded()', function () {
   before(function () {
@@ -21,8 +21,8 @@ describe('bodyParser.urlencoded()', function () {
   })
 
   it('should 400 when invalid content-length', function (done) {
-    var urlencodedParser = bodyParser.urlencoded()
-    var server = createServer(function (req, res, next) {
+    const urlencodedParser = bodyParser.urlencoded()
+    const server = createServer(function (req, res, next) {
       req.headers['content-length'] = '20' // bad length
       urlencodedParser(req, res, next)
     })
@@ -47,11 +47,11 @@ describe('bodyParser.urlencoded()', function () {
     assert.throws(createServer.bind(null, { defaultCharset: 'utf-16' }), /TypeError: option defaultCharset must be either utf-8 or iso-8859-1/)
   })
 
-  var extendedValues = [true, false]
+  const extendedValues = [true, false]
   extendedValues.forEach(function (extended) {
     describe('in ' + (extended ? 'extended' : 'simple') + ' mode', function () {
       it('should parse x-www-form-urlencoded with an explicit iso-8859-1 encoding', function (done) {
-        var server = createServer({ extended: extended })
+        const server = createServer({ extended: extended })
         request(server)
           .post('/')
           .set('Content-Type', 'application/x-www-form-urlencoded; charset=iso-8859-1')
@@ -60,7 +60,7 @@ describe('bodyParser.urlencoded()', function () {
       })
 
       it('should parse x-www-form-urlencoded with unspecified iso-8859-1 encoding when the defaultCharset is set to iso-8859-1', function (done) {
-        var server = createServer({ defaultCharset: 'iso-8859-1', extended: extended })
+        const server = createServer({ defaultCharset: 'iso-8859-1', extended: extended })
         request(server)
           .post('/')
           .set('Content-Type', 'application/x-www-form-urlencoded')
@@ -69,7 +69,7 @@ describe('bodyParser.urlencoded()', function () {
       })
 
       it('should parse x-www-form-urlencoded with an unspecified iso-8859-1 encoding when the utf8 sentinel has a value of %26%2310003%3B', function (done) {
-        var server = createServer({ charsetSentinel: true, extended: extended })
+        const server = createServer({ charsetSentinel: true, extended: extended })
         request(server)
           .post('/')
           .set('Content-Type', 'application/x-www-form-urlencoded')
@@ -78,7 +78,7 @@ describe('bodyParser.urlencoded()', function () {
       })
 
       it('should parse x-www-form-urlencoded with an unspecified utf-8 encoding when the utf8 sentinel has a value of %E2%9C%93 and the defaultCharset is iso-8859-1', function (done) {
-        var server = createServer({ charsetSentinel: true, extended: extended })
+        const server = createServer({ charsetSentinel: true, extended: extended })
         request(server)
           .post('/')
           .set('Content-Type', 'application/x-www-form-urlencoded')
@@ -87,7 +87,7 @@ describe('bodyParser.urlencoded()', function () {
       })
 
       it('should not leave an empty string parameter when removing the utf8 sentinel from the start of the string', function (done) {
-        var server = createServer({ charsetSentinel: true, extended: extended })
+        const server = createServer({ charsetSentinel: true, extended: extended })
         request(server)
           .post('/')
           .set('Content-Type', 'application/x-www-form-urlencoded')
@@ -96,7 +96,7 @@ describe('bodyParser.urlencoded()', function () {
       })
 
       it('should not leave an empty string parameter when removing the utf8 sentinel from the middle of the string', function (done) {
-        var server = createServer({ charsetSentinel: true, extended: extended })
+        const server = createServer({ charsetSentinel: true, extended: extended })
         request(server)
           .post('/')
           .set('Content-Type', 'application/x-www-form-urlencoded')
@@ -105,7 +105,7 @@ describe('bodyParser.urlencoded()', function () {
       })
 
       it('should not leave an empty string parameter when removing the utf8 sentinel from the end of the string', function (done) {
-        var server = createServer({ charsetSentinel: true, extended: extended })
+        const server = createServer({ charsetSentinel: true, extended: extended })
         request(server)
           .post('/')
           .set('Content-Type', 'application/x-www-form-urlencoded')
@@ -125,8 +125,8 @@ describe('bodyParser.urlencoded()', function () {
   })
 
   it('should handle consumed stream', function (done) {
-    var urlencodedParser = bodyParser.urlencoded()
-    var server = createServer(function (req, res, next) {
+    const urlencodedParser = bodyParser.urlencoded()
+    const server = createServer(function (req, res, next) {
       req.on('end', function () {
         urlencodedParser(req, res, next)
       })
@@ -141,8 +141,8 @@ describe('bodyParser.urlencoded()', function () {
   })
 
   it('should handle duplicated middleware', function (done) {
-    var urlencodedParser = bodyParser.urlencoded()
-    var server = createServer(function (req, res, next) {
+    const urlencodedParser = bodyParser.urlencoded()
+    const server = createServer(function (req, res, next) {
       urlencodedParser(req, res, function (err) {
         if (err) return next(err)
         urlencodedParser(req, res, next)
@@ -233,9 +233,9 @@ describe('bodyParser.urlencoded()', function () {
       })
 
       it('should parse array index notation with large array', function (done) {
-        var str = 'f[0]=0'
+        let str = 'f[0]=0'
 
-        for (var i = 1; i < 500; i++) {
+        for (let i = 1; i < 500; i++) {
           str += '&f[' + i + ']=' + i.toString(16)
         }
 
@@ -244,7 +244,7 @@ describe('bodyParser.urlencoded()', function () {
           .set('Content-Type', 'application/x-www-form-urlencoded')
           .send(str)
           .expect(function (res) {
-            var obj = JSON.parse(res.text)
+            const obj = JSON.parse(res.text)
             assert.strictEqual(Object.keys(obj).length, 1)
             assert.strictEqual(Array.isArray(obj.f), true)
             assert.strictEqual(obj.f.length, 500)
@@ -261,9 +261,9 @@ describe('bodyParser.urlencoded()', function () {
       })
 
       it('should parse deep object', function (done) {
-        var str = 'foo'
+        let str = 'foo'
 
-        for (var i = 0; i < 32; i++) {
+        for (let i = 0; i < 32; i++) {
           str += '[p]'
         }
 
@@ -274,12 +274,12 @@ describe('bodyParser.urlencoded()', function () {
           .set('Content-Type', 'application/x-www-form-urlencoded')
           .send(str)
           .expect(function (res) {
-            var obj = JSON.parse(res.text)
+            const obj = JSON.parse(res.text)
             assert.strictEqual(Object.keys(obj).length, 1)
             assert.strictEqual(typeof obj.foo, 'object')
 
-            var depth = 0
-            var ref = obj.foo
+            let depth = 0
+            let ref = obj.foo
             while ((ref = ref.p)) { depth++ }
             assert.strictEqual(depth, 32)
           })
@@ -324,8 +324,8 @@ describe('bodyParser.urlencoded()', function () {
       })
 
       it('should parse deeply nested objects', function (done) {
-        var deepObject = 'a'
-        for (var i = 0; i < 32; i++) {
+        let deepObject = 'a'
+        for (let i = 0; i < 32; i++) {
           deepObject += '[p]'
         }
         deepObject += '=value'
@@ -335,9 +335,9 @@ describe('bodyParser.urlencoded()', function () {
           .set('Content-Type', 'application/x-www-form-urlencoded')
           .send(deepObject)
           .expect(function (res) {
-            var obj = JSON.parse(res.text)
-            var depth = 0
-            var ref = obj.a
+            const obj = JSON.parse(res.text)
+            let depth = 0
+            let ref = obj.a
             while ((ref = ref.p)) { depth++ }
             assert.strictEqual(depth, 32)
           })
@@ -345,8 +345,8 @@ describe('bodyParser.urlencoded()', function () {
       })
 
       it('should not parse beyond the specified depth', function (done) {
-        var deepObject = 'a'
-        for (var i = 0; i < 33; i++) {
+        let deepObject = 'a'
+        for (let i = 0; i < 33; i++) {
           deepObject += '[p]'
         }
         deepObject += '=value'
@@ -367,7 +367,7 @@ describe('bodyParser.urlencoded()', function () {
       })
 
       it('should not accept content-encoding', function (done) {
-        var test = request(this.server).post('/')
+        const test = request(this.server).post('/')
         test.set('Content-Encoding', 'gzip')
         test.set('Content-Type', 'application/x-www-form-urlencoded')
         test.write(Buffer.from('1f8b080000000000000bcb4bcc4db57db16e170099a4bad608000000', 'hex'))
@@ -381,7 +381,7 @@ describe('bodyParser.urlencoded()', function () {
       })
 
       it('should accept content-encoding', function (done) {
-        var test = request(this.server).post('/')
+        const test = request(this.server).post('/')
         test.set('Content-Encoding', 'gzip')
         test.set('Content-Type', 'application/x-www-form-urlencoded')
         test.write(Buffer.from('1f8b080000000000000bcb4bcc4db57db16e170099a4bad608000000', 'hex'))
@@ -392,7 +392,7 @@ describe('bodyParser.urlencoded()', function () {
 
   describe('with limit option', function () {
     it('should 413 when over limit with Content-Length', function (done) {
-      var buf = Buffer.alloc(1024, '.')
+      const buf = Buffer.alloc(1024, '.')
       request(createServer({ limit: '1kb' }))
         .post('/')
         .set('Content-Type', 'application/x-www-form-urlencoded')
@@ -402,9 +402,9 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should 413 when over limit with chunked encoding', function (done) {
-      var buf = Buffer.alloc(1024, '.')
-      var server = createServer({ limit: '1kb' })
-      var test = request(server).post('/')
+      const buf = Buffer.alloc(1024, '.')
+      const server = createServer({ limit: '1kb' })
+      const test = request(server).post('/')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
       test.set('Transfer-Encoding', 'chunked')
       test.write('str=')
@@ -413,8 +413,8 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should 413 when inflated body over limit', function (done) {
-      var server = createServer({ limit: '1kb' })
-      var test = request(server).post('/')
+      const server = createServer({ limit: '1kb' })
+      const test = request(server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
       test.write(Buffer.from('1f8b080000000000000a2b2e29b2d51b05a360148c580000a0351f9204040000', 'hex'))
@@ -422,7 +422,7 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should accept number of bytes', function (done) {
-      var buf = Buffer.alloc(1024, '.')
+      const buf = Buffer.alloc(1024, '.')
       request(createServer({ limit: 1024 }))
         .post('/')
         .set('Content-Type', 'application/x-www-form-urlencoded')
@@ -431,9 +431,9 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should not change when options altered', function (done) {
-      var buf = Buffer.alloc(1024, '.')
-      var options = { limit: '1kb' }
-      var server = createServer(options)
+      const buf = Buffer.alloc(1024, '.')
+      const options = { limit: '1kb' }
+      const server = createServer(options)
 
       options.limit = '100kb'
 
@@ -445,9 +445,9 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should not hang response', function (done) {
-      var buf = Buffer.alloc(10240, '.')
-      var server = createServer({ limit: '8kb' })
-      var test = request(server).post('/')
+      const buf = Buffer.alloc(10240, '.')
+      const server = createServer({ limit: '8kb' })
+      const test = request(server).post('/')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
       test.write(buf)
       test.write(buf)
@@ -456,8 +456,8 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should not error when inflating', function (done) {
-      var server = createServer({ limit: '1kb' })
-      var test = request(server).post('/')
+      const server = createServer({ limit: '1kb' })
+      const test = request(server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
       test.write(Buffer.from('1f8b080000000000000a2b2e29b2d51b05a360148c580000a0351f92040400', 'hex'))
@@ -634,7 +634,7 @@ describe('bodyParser.urlencoded()', function () {
 
     describe('when a function', function () {
       it('should parse when truthy value returned', function (done) {
-        var server = createServer({ type: accept })
+        const server = createServer({ type: accept })
 
         function accept (req) {
           return req.headers['content-type'] === 'application/vnd.something'
@@ -648,19 +648,19 @@ describe('bodyParser.urlencoded()', function () {
       })
 
       it('should work without content-type', function (done) {
-        var server = createServer({ type: accept })
+        const server = createServer({ type: accept })
 
         function accept (req) {
           return true
         }
 
-        var test = request(server).post('/')
+        const test = request(server).post('/')
         test.write('user=tobi')
         test.expect(200, '{"user":"tobi"}', done)
       })
 
       it('should not invoke without a body', function (done) {
-        var server = createServer({ type: accept })
+        const server = createServer({ type: accept })
 
         function accept (req) {
           throw new Error('oops!')
@@ -680,7 +680,7 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should error from verify', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           if (buf[0] === 0x20) throw new Error('no leading space')
         }
@@ -694,10 +694,10 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should allow custom codes', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           if (buf[0] !== 0x20) return
-          var err = new Error('no leading space')
+          const err = new Error('no leading space')
           err.status = 400
           throw err
         }
@@ -711,10 +711,10 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should allow custom type', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           if (buf[0] !== 0x20) return
-          var err = new Error('no leading space')
+          const err = new Error('no leading space')
           err.type = 'foo.bar'
           throw err
         }
@@ -728,7 +728,7 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should allow pass-through', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           if (buf[0] === 0x5b) throw new Error('no arrays')
         }
@@ -742,13 +742,13 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should 415 on unknown charset prior to verify', function (done) {
-      var server = createServer({
+      const server = createServer({
         verify: function (req, res, buf) {
           throw new Error('unexpected verify call')
         }
       })
 
-      var test = request(server).post('/')
+      const test = request(server).post('/')
       test.set('Content-Type', 'application/x-www-form-urlencoded; charset=x-bogus')
       test.write(Buffer.from('00000000', 'hex'))
       test.expect(415, '[charset.unsupported] unsupported charset "X-BOGUS"', done)
@@ -757,15 +757,15 @@ describe('bodyParser.urlencoded()', function () {
 
   describe('async local storage', function () {
     before(function () {
-      var urlencodedParser = bodyParser.urlencoded()
-      var store = { foo: 'bar' }
+      const urlencodedParser = bodyParser.urlencoded()
+      const store = { foo: 'bar' }
 
       this.server = createServer(function (req, res, next) {
-        var asyncLocalStorage = new AsyncLocalStorage()
+        const asyncLocalStorage = new AsyncLocalStorage()
 
         asyncLocalStorage.run(store, function () {
           urlencodedParser(req, res, function (err) {
-            var local = asyncLocalStorage.getStore()
+            const local = asyncLocalStorage.getStore()
 
             if (local) {
               res.setHeader('x-store-foo', String(local.foo))
@@ -800,7 +800,7 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should presist store when inflated', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
       test.write(Buffer.from('1f8b080000000000000bcb4bcc4db57db16e170099a4bad608000000', 'hex'))
@@ -811,7 +811,7 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should presist store when inflate error', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
       test.write(Buffer.from('1f8b080000000000000bcb4bcc4db57db16e170099a4bad6080000', 'hex'))
@@ -837,14 +837,14 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should parse utf-8', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'application/x-www-form-urlencoded; charset=utf-8')
       test.write(Buffer.from('6e616d653de8aeba', 'hex'))
       test.expect(200, '{"name":"论"}', done)
     })
 
     it('should parse when content-length != char length', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'application/x-www-form-urlencoded; charset=utf-8')
       test.set('Content-Length', '7')
       test.write(Buffer.from('746573743dc3a5', 'hex'))
@@ -852,14 +852,14 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should default to utf-8', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
       test.write(Buffer.from('6e616d653de8aeba', 'hex'))
       test.expect(200, '{"name":"论"}', done)
     })
 
     it('should fail on unknown charset', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'application/x-www-form-urlencoded; charset=koi8-r')
       test.write(Buffer.from('6e616d653dcec5d4', 'hex'))
       test.expect(415, '[charset.unsupported] unsupported charset "KOI8-R"', done)
@@ -872,14 +872,14 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should parse without encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
       test.write(Buffer.from('6e616d653de8aeba', 'hex'))
       test.expect(200, '{"name":"论"}', done)
     })
 
     it('should support identity encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'identity')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
       test.write(Buffer.from('6e616d653de8aeba', 'hex'))
@@ -887,7 +887,7 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should support gzip encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
       test.write(Buffer.from('1f8b080000000000000bcb4bcc4db57db16e170099a4bad608000000', 'hex'))
@@ -895,7 +895,7 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should support deflate encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'deflate')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
       test.write(Buffer.from('789ccb4bcc4db57db16e17001068042f', 'hex'))
@@ -903,7 +903,7 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should support brotli encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'br')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
       test.write(Buffer.from('8b03806e616d653de8aeba03', 'hex'))
@@ -911,7 +911,7 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should be case-insensitive', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'GZIP')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
       test.write(Buffer.from('1f8b080000000000000bcb4bcc4db57db16e170099a4bad608000000', 'hex'))
@@ -919,7 +919,7 @@ describe('bodyParser.urlencoded()', function () {
     })
 
     it('should 415 on unknown encoding', function (done) {
-      var test = request(this.server).post('/')
+      const test = request(this.server).post('/')
       test.set('Content-Encoding', 'nulls')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
       test.write(Buffer.from('000000000000', 'hex'))
@@ -929,7 +929,7 @@ describe('bodyParser.urlencoded()', function () {
 })
 
 function createManyParams (count) {
-  var str = ''
+  let str = ''
 
   if (count === 0) {
     return str
@@ -937,8 +937,8 @@ function createManyParams (count) {
 
   str += '0=0'
 
-  for (var i = 1; i < count; i++) {
-    var n = i.toString(36)
+  for (let i = 1; i < count; i++) {
+    const n = i.toString(36)
     str += '&' + n + '=' + n
   }
 
@@ -946,7 +946,7 @@ function createManyParams (count) {
 }
 
 function createServer (opts) {
-  var _bodyParser = typeof opts !== 'function'
+  const _bodyParser = typeof opts !== 'function'
     ? bodyParser.urlencoded(opts)
     : opts
 


### PR DESCRIPTION
Some parts of the codebase already use const/let some untouched parts not. I enabled the `no-var` eslint rule to keep it consistent.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
