### PR TITLE
2.3.0

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,11 @@
-unreleased
+2.3.0 / 2026-06-15
 ========================
 
 * fix: use static exports instead of lazy getters to improve ESM compatibility
 * feat: add subpath exports for individual parsers
+* fix: improve `limit` option validation (#698)
+  * Invalid `limit` values (e.g. unparseable strings or `NaN`) now throw instead of being silently ignored, which previously disabled size limit enforcement
+  * `null` and `undefined` fall back to the default 100kb limit
 * deps:
   * content-type@^2.0.0
   * http-errors@^2.0.1

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "body-parser",
   "description": "Node.js body parsing middleware",
-  "version": "2.2.2",
+  "version": "2.3.0",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",
     "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)"


### PR DESCRIPTION
## What's included in the `HISTORY.md` 

```
2.3.0 / 2026-06-15
========================

* fix: use static exports instead of lazy getters to improve ESM compatibility
* feat: add subpath exports for individual parsers
* fix: improve `limit` option validation (#698)
  * Invalid `limit` values (e.g. unparseable strings or `NaN`) now throw instead of being silently ignored, which previously disabled size limit enforcement
  * `null` and `undefined` fall back to the default 100kb limit
* deps:
  * content-type@^2.0.0
  * http-errors@^2.0.1
  * iconv-lite^0.7.2
  * qs@^6.15.2
  * raw-body@^3.0.2
  * type-is@^2.1.0
```

## What's Changed
* build(deps): bump actions/download-artifact from 6.0.0 to 7.0.0 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/681
* build(deps): bump actions/checkout from 5.0.0 to 6.0.1 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/682
* build(deps): bump actions/setup-node from 6.0.0 to 6.1.0 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/683
* build(deps): bump actions/upload-artifact from 5.0.0 to 6.0.0 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/685
* build(deps): bump github/codeql-action from 4.31.2 to 4.31.9 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/684
* perf(urlencoded): move empty-body guard to avoid extra function closure by @Phillip9587 in https://github.com/expressjs/body-parser/pull/647
* Improve ESM compatibility by @Phillip9587 in https://github.com/expressjs/body-parser/pull/697
* docs: add recommendations for configuring payload limits by @bjohansebas in https://github.com/expressjs/body-parser/pull/699
* build(deps): bump actions/setup-node from 6.1.0 to 6.2.0 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/701
* build(deps): bump github/codeql-action from 4.31.10 to 4.32.0 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/702
* build(deps): bump actions/checkout from 6.0.1 to 6.0.2 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/700
* chore:  add explicit type commonjs to package.json by @Phillip9587 in https://github.com/expressjs/body-parser/pull/711
* deps: update dependencies to latest versions by @Phillip9587 in https://github.com/expressjs/body-parser/pull/708
* build(deps): bump actions/download-artifact from 7.0.0 to 8.0.0 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/712
* build(deps): bump github/codeql-action from 4.32.0 to 4.32.4 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/713
* build(deps): bump actions/upload-artifact from 6.0.0 to 7.0.0 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/714
* fix: improve limit option validation by @Phillip9587 in https://github.com/expressjs/body-parser/pull/698
* build(deps): bump github/codeql-action from 4.32.4 to 4.35.1 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/719
* build(deps): bump actions/setup-node from 6.2.0 to 6.3.0 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/718
* build(deps): bump actions/download-artifact from 8.0.0 to 8.0.1 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/717
* perf: eliminate conditional check in json strict mode hot path by @Phillip9587 in https://github.com/expressjs/body-parser/pull/651
* ci: add node.js 26 to text matrix by @Phillip9587 in https://github.com/expressjs/body-parser/pull/726
* build(deps): bump actions/setup-node from 6.3.0 to 6.4.0 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/725
* build(deps): bump actions/upload-artifact from 7.0.0 to 7.0.1 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/724
* build(deps): bump github/codeql-action from 4.35.1 to 4.35.3 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/723
* Upgrade "content-type" by @blakeembrey in https://github.com/expressjs/body-parser/pull/728
* refactor: switch to const/let and enable eslint no-var rule by @Phillip9587 in https://github.com/expressjs/body-parser/pull/729
* Update outdated reference to MDN docs by @krzysdz in https://github.com/expressjs/body-parser/pull/730
* build(deps): bump github/codeql-action from 4.35.3 to 4.36.1 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/731
* build(deps): bump actions/checkout from 6.0.2 to 6.0.3 by @dependabot[bot] in https://github.com/expressjs/body-parser/pull/732
* chore: updated deps to latest by @Phillip9587 in https://github.com/expressjs/body-parser/pull/733

## New Contributors
* @krzysdz made their first contribution in https://github.com/expressjs/body-parser/pull/730

**Full Changelog**: https://github.com/expressjs/body-parser/compare/v2.3.0...main