### PR TITLE
fix: avoid mutating read options when reading body

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -79,38 +79,37 @@ function read (req, res, next, parse, debug, options) {
   }
 
   let length
-  const opts = options
   let stream
 
-  // read options
-  const verify = opts.verify
+  const verify = options.verify
 
   try {
     // get the content stream
-    stream = contentstream(req, debug, opts.inflate)
+    stream = contentstream(req, debug, options.inflate)
     length = stream.length
     stream.length = undefined
   } catch (err) {
     return next(err)
   }
 
-  // set raw-body options
-  opts.length = length
-  opts.encoding = verify
-    ? null
-    : encoding
-
   // assert charset is supported
-  if (opts.encoding === null && encoding !== null && !iconv.encodingExists(encoding)) {
+  if (verify && encoding !== null && !iconv.encodingExists(encoding)) {
     return next(createError(415, 'unsupported charset "' + encoding.toUpperCase() + '"', {
       charset: encoding.toLowerCase(),
       type: 'charset.unsupported'
     }))
   }
 
+  // set raw-body options
+  const rawBodyOptions = {
+    length,
+    encoding: verify ? null : encoding,
+    limit: options.limit
+  }
+
   // read body
   debug('read body')
-  getBody(stream, opts, function (error, body) {
+  getBody(stream, rawBodyOptions, function (error, body) {
     if (error) {
       let _error
 


### PR DESCRIPTION
The parser read options were created once per middleware instance and reused for each request. `read()` was aliasing that shared object and adding per-request `length` and `encoding` fields before passing it to `raw-body`.

Pass `raw-body` an explicit `rawBodyOptions` object containing the per-request values it needs.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
