### PR TITLE
Release: 1.20.6

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,4 +1,4 @@
-unreleased
+1.20.6 / 2026-07-09
 ===================
 * fix: improve `limit` option validation (#698)
   * Invalid `limit` values (e.g. unparseable strings or `NaN`) now throw instead of being silently ignored, which previously disabled size limit enforcement

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "body-parser",
   "description": "Node.js body parsing middleware",
-  "version": "1.20.5",
+  "version": "1.20.6",
   "contributors": [
     "Douglas Christopher Wilson <doug@somethingdoug.com>",
     "Jonathan Ong <me@jongleberry.com> (http://jongleberry.com)"


### PR DESCRIPTION
## What's included in the `HISTORY.md` 

```
1.20.6 / 2026-07-09
===================
* fix: improve `limit` option validation (#698)
  * Invalid `limit` values (e.g. unparseable strings or `NaN`) now throw instead of being silently ignored, which previously disabled size limit enforcement
  * `null` and `undefined` fall back to the default 100kb limit
```

## What's Changed
* fix: improve limit option validation by @Phillip9587 in https://github.com/expressjs/body-parser/pull/741


**Full Changelog**: https://github.com/expressjs/body-parser/compare/1.20.5...1.x