### PR TITLE
docs: include security fix in 2.3.0 changes

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 2.3.0 / 2026-06-15
 ========================
 
+* Security fix for [GHSA-v422-hmwv-36x6](https://github.com/expressjs/body-parser/security/advisories/GHSA-v422-hmwv-36x6)
 * fix: use static exports instead of lazy getters to improve ESM compatibility
 * feat: add subpath exports for individual parsers
 * fix: improve `limit` option validation (#698)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -108,6 +108,7 @@ This incorporates all changes after 1.19.1 up to 1.20.2.
     - it is left `undefined` unless a body is parsed
   * `urlencoded` parser now defaults `extended` to `false`
   * Use `on-finished` to determine when body read
+
 1.20.6 / 2026-07-09
 ===================
 * Security fix for [GHSA-v422-hmwv-36x6](https://github.com/expressjs/body-parser/security/advisories/GHSA-v422-hmwv-36x6)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -108,6 +108,19 @@ This incorporates all changes after 1.19.1 up to 1.20.2.
     - it is left `undefined` unless a body is parsed
   * `urlencoded` parser now defaults `extended` to `false`
   * Use `on-finished` to determine when body read
+1.20.6 / 2026-07-09
+===================
+* Security fix for [GHSA-v422-hmwv-36x6](https://github.com/expressjs/body-parser/security/advisories/GHSA-v422-hmwv-36x6)
+* fix: improve `limit` option validation (#698)
+  * Invalid `limit` values (e.g. unparseable strings or `NaN`) now throw instead of being silently ignored, which previously disabled size limit enforcement
+  * `null` and `undefined` fall back to the default 100kb limit
+
+1.20.5 / 2026-04-24
+===================
+* refactor(json): simplify strict mode error string construction
+* fix: extended urlencoded parsing of arrays with >100 elements (#716)
+* deps: qs@~6.15.1
+* 
 
 1.20.4 / 2025-12-01
 ===================


### PR DESCRIPTION
Ref: https://github.com/expressjs/body-parser/security/advisories/GHSA-v422-hmwv-36x6
