### PR TITLE
test: fix 'presist' typo in test descriptions

### DIFF
--- a/test/json.js
+++ b/test/json.js
@@ -545,7 +545,7 @@ describe('bodyParser.json()', function () {
       })
     })
 
-    it('should presist store', function (done) {
+    it('should persist store', function (done) {
       request(this.server)
         .post('/')
         .set('Content-Type', 'application/json')
@@ -556,7 +556,7 @@ describe('bodyParser.json()', function () {
         .end(done)
     })
 
-    it('should presist store when unmatched content-type', function (done) {
+    it('should persist store when unmatched content-type', function (done) {
       request(this.server)
         .post('/')
         .set('Content-Type', 'application/fizzbuzz')
@@ -567,7 +567,7 @@ describe('bodyParser.json()', function () {
         .end(done)
     })
 
-    it('should presist store when inflated', function (done) {
+    it('should persist store when inflated', function (done) {
       const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/json')
@@ -578,7 +578,7 @@ describe('bodyParser.json()', function () {
       test.end(done)
     })
 
-    it('should presist store when inflate error', function (done) {
+    it('should persist store when inflate error', function (done) {
       const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/json')
@@ -588,7 +588,7 @@ describe('bodyParser.json()', function () {
       test.end(done)
     })
 
-    it('should presist store when parse error', function (done) {
+    it('should persist store when parse error', function (done) {
       request(this.server)
         .post('/')
         .set('Content-Type', 'application/json')
@@ -598,7 +598,7 @@ describe('bodyParser.json()', function () {
         .end(done)
     })
 
-    it('should presist store when limit exceeded', function (done) {
+    it('should persist store when limit exceeded', function (done) {
       request(this.server)
         .post('/')
         .set('Content-Type', 'application/json')

--- a/test/raw.js
+++ b/test/raw.js
@@ -347,7 +347,7 @@ describe('bodyParser.raw()', function () {
       })
     })
 
-    it('should presist store', function (done) {
+    it('should persist store', function (done) {
       request(this.server)
         .post('/')
         .set('Content-Type', 'application/octet-stream')
@@ -358,7 +358,7 @@ describe('bodyParser.raw()', function () {
         .end(done)
     })
 
-    it('should presist store when unmatched content-type', function (done) {
+    it('should persist store when unmatched content-type', function (done) {
       request(this.server)
         .post('/')
         .set('Content-Type', 'application/fizzbuzz')
@@ -369,7 +369,7 @@ describe('bodyParser.raw()', function () {
         .end(done)
     })
 
-    it('should presist store when inflated', function (done) {
+    it('should persist store when inflated', function (done) {
       const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/octet-stream')
@@ -380,7 +380,7 @@ describe('bodyParser.raw()', function () {
       test.end(done)
     })
 
-    it('should presist store when inflate error', function (done) {
+    it('should persist store when inflate error', function (done) {
       const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/octet-stream')
@@ -390,7 +390,7 @@ describe('bodyParser.raw()', function () {
       test.end(done)
     })
 
-    it('should presist store when limit exceeded', function (done) {
+    it('should persist store when limit exceeded', function (done) {
       request(this.server)
         .post('/')
         .set('Content-Type', 'application/octet-stream')

--- a/test/text.js
+++ b/test/text.js
@@ -388,7 +388,7 @@ describe('bodyParser.text()', function () {
       })
     })
 
-    it('should presist store', function (done) {
+    it('should persist store', function (done) {
       request(this.server)
         .post('/')
         .set('Content-Type', 'text/plain')
@@ -399,7 +399,7 @@ describe('bodyParser.text()', function () {
         .end(done)
     })
 
-    it('should presist store when unmatched content-type', function (done) {
+    it('should persist store when unmatched content-type', function (done) {
       request(this.server)
         .post('/')
         .set('Content-Type', 'application/fizzbuzz')
@@ -410,7 +410,7 @@ describe('bodyParser.text()', function () {
         .end(done)
     })
 
-    it('should presist store when inflated', function (done) {
+    it('should persist store when inflated', function (done) {
       const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'text/plain')
@@ -421,7 +421,7 @@ describe('bodyParser.text()', function () {
       test.end(done)
     })
 
-    it('should presist store when inflate error', function (done) {
+    it('should persist store when inflate error', function (done) {
       const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'text/plain')
@@ -431,7 +431,7 @@ describe('bodyParser.text()', function () {
       test.end(done)
     })
 
-    it('should presist store when limit exceeded', function (done) {
+    it('should persist store when limit exceeded', function (done) {
       request(this.server)
         .post('/')
         .set('Content-Type', 'text/plain')

--- a/test/urlencoded.js
+++ b/test/urlencoded.js
@@ -777,7 +777,7 @@ describe('bodyParser.urlencoded()', function () {
       })
     })
 
-    it('should presist store', function (done) {
+    it('should persist store', function (done) {
       request(this.server)
         .post('/')
         .set('Content-Type', 'application/x-www-form-urlencoded')
@@ -788,7 +788,7 @@ describe('bodyParser.urlencoded()', function () {
         .end(done)
     })
 
-    it('should presist store when unmatched content-type', function (done) {
+    it('should persist store when unmatched content-type', function (done) {
       request(this.server)
         .post('/')
         .set('Content-Type', 'application/fizzbuzz')
@@ -799,7 +799,7 @@ describe('bodyParser.urlencoded()', function () {
         .end(done)
     })
 
-    it('should presist store when inflated', function (done) {
+    it('should persist store when inflated', function (done) {
       const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
@@ -810,7 +810,7 @@ describe('bodyParser.urlencoded()', function () {
       test.end(done)
     })
 
-    it('should presist store when inflate error', function (done) {
+    it('should persist store when inflate error', function (done) {
       const test = request(this.server).post('/')
       test.set('Content-Encoding', 'gzip')
       test.set('Content-Type', 'application/x-www-form-urlencoded')
@@ -820,7 +820,7 @@ describe('bodyParser.urlencoded()', function () {
       test.end(done)
     })
 
-    it('should presist store when limit exceeded', function (done) {
+    it('should persist store when limit exceeded', function (done) {
       request(this.server)
         .post('/')
         .set('Content-Type', 'application/x-www-form-urlencoded')


### PR DESCRIPTION
## Summary

Fix a recurring misspelling of "presist" -> "persist" found in AsyncLocalStorage store test descriptions across four test files.

codespell detected 21 instances of the typo `presist` in:
- `test/json.js` (6 occurrences)
- `test/raw.js` (5 occurrences)
- `test/text.js` (5 occurrences)
- `test/urlencoded.js` (5 occurrences)

All were in `it('should presist store...')` test description strings.

## Test plan

- [x] No logic changes -- only string literals in test descriptions were modified
- [x] `codespell` reports no remaining instances of `presist` in `.js` files

Generated with [Claude Code](https://claude.com/claude-code)