### PR TITLE
perf: inline content stream setup

### DIFF
--- a/lib/read.js
+++ b/lib/read.js
@@ -84,10 +84,25 @@ function read (req, res, next, parse, debug, options) {
   const verify = options.verify
 
   try {
+    const contentEncoding = (req.headers['content-encoding'] || 'identity').toLowerCase()
+
+    debug('content-encoding "%s"', contentEncoding)
+
+    if (options.inflate === false && contentEncoding !== 'identity') {
+      throw createError(415, 'content encoding unsupported', {
+        encoding: contentEncoding,
+        type: 'encoding.unsupported'
+      })
+    }
+
     // get the content stream
-    stream = contentstream(req, debug, options.inflate)
-    length = stream.length
-    stream.length = undefined
+    if (contentEncoding === 'identity') {
+      length = req.headers['content-length']
+      stream = req
+    } else {
+      stream = createDecompressionStream(contentEncoding, debug)
+      req.pipe(stream)
+    }
   } catch (err) {
     return next(err)
   }
@@ -169,38 +184,6 @@ function read (req, res, next, parse, debug, options) {
 
     next()
   })
-}
-
-/**
- * Get the content stream of the request.
- *
- * @param {Object} req
- * @param {Function} debug
- * @param {boolean} inflate
- * @returns {Object}
- * @private
- */
-function contentstream (req, debug, inflate) {
-  const encoding = (req.headers['content-encoding'] || 'identity').toLowerCase()
-  const length = req.headers['content-length']
-
-  debug('content-encoding "%s"', encoding)
-
-  if (inflate === false && encoding !== 'identity') {
-    throw createError(415, 'content encoding unsupported', {
-      encoding: encoding,
-      type: 'encoding.unsupported'
-    })
-  }
-
-  if (encoding === 'identity') {
-    req.length = length
-    return req
-  }
-
-  const stream = createDecompressionStream(encoding, debug)
-  req.pipe(stream)
-  return stream
 }
 
 /**


### PR DESCRIPTION
Inline content stream initialization into `read` to keep the stream and content-length state local. Only read `content-length` when needed and avoid temporary mutations of `req.length` and `stream.length`.

<!--
Thank you for your pull request. Please provide a description and 
note the Certificate of Origin below. 

-->

<!--
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
